### PR TITLE
[Fix] #11 - build.js 토큰 값 단위 파싱 처리 추가

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,6 +2,9 @@ import StyleDictionary from 'style-dictionary';
 
 const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
 
+// Strips "px" or "%" units from token values and returns a plain number string.
+const toNumber = (val) => parseFloat(String(val).replace('px', '').replace('%', ''));
+
 const fileHeader = (filename) =>
 `//
 //  ${filename}
@@ -38,7 +41,7 @@ StyleDictionary.registerFormat({
         else if (cat === 'lineHeight') name = `lineHeight${last}`;
         else if (last === 'default') name = '`default`';
         else name = last;
-        output += `        static let ${name}: CGFloat = ${token.$value ?? token.value}\n`;
+        output += `        static let ${name}: CGFloat = ${toNumber(token.$value ?? token.value)}\n`;
       }
       output += `    }\n`;
     }
@@ -67,7 +70,7 @@ StyleDictionary.registerFormat({
       output += `    enum ${capitalize(cat)} {\n`;
       for (const token of tokens) {
         const last = token.path[token.path.length - 1];
-        output += `        static let size${last}: CGFloat = ${token.$value ?? token.value}\n`;
+        output += `        static let size${last}: CGFloat = ${toNumber(token.$value ?? token.value)}\n`;
       }
       output += `    }\n`;
     }


### PR DESCRIPTION
## 작업 요약
toNumber() 헬퍼를 추가하여 "12px", "-1.5%" 등 단위가 포함된 W3C DTCG 포맷 토큰 값을 CGFloat으로 변환했습니다.

## PR Point
없음

## 참고사항
없음

close #11 