### PR TITLE
[Feat] #14 - Semantic Typography 토큰 생성 및 UILabel extension 추가

### DIFF
--- a/.github/workflows/style-dictionary.yml
+++ b/.github/workflows/style-dictionary.yml
@@ -90,7 +90,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: '[Style Dictionary] Update generated Swift token files'
-          file_pattern: 'MDS/Sources/MDS/Foundation/Base/Base*.swift'
+          file_pattern: 'MDS/Sources/MDS/Foundation/Base/Base*.swift MDS/Sources/MDS/Tokens/Typography.swift'
 
       - name: Create Pull Request if not exists
         env:

--- a/MDS/Sources/MDS/Components/UILabel+Typography.swift
+++ b/MDS/Sources/MDS/Components/UILabel+Typography.swift
@@ -1,0 +1,23 @@
+//
+//  UILabel+Typography.swift
+//  MDS
+//
+
+import UIKit
+
+extension UILabel {
+    public func setTypography(_ style: MDSFont) {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.minimumLineHeight = style.lineHeight
+        paragraphStyle.maximumLineHeight = style.lineHeight
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: style.font,
+            .kern: style.letterSpacing,
+            .paragraphStyle: paragraphStyle,
+            .baselineOffset: (style.lineHeight - style.font.lineHeight) / 4
+        ]
+
+        attributedText = NSAttributedString(string: text ?? "", attributes: attributes)
+    }
+}

--- a/MDS/Sources/MDS/Foundation/MDSFont.swift
+++ b/MDS/Sources/MDS/Foundation/MDSFont.swift
@@ -1,0 +1,12 @@
+//
+//  MDSFont.swift
+//  MDS
+//
+
+import UIKit
+
+public struct MDSFont {
+    public let font: UIFont
+    public let lineHeight: CGFloat
+    public let letterSpacing: CGFloat
+}

--- a/build.js
+++ b/build.js
@@ -80,6 +80,52 @@ StyleDictionary.registerFormat({
   }
 });
 
+const fontNameMap = {
+  '700': 'Pretendard-Bold',
+  '600': 'Pretendard-SemiBold',
+  '400': 'Pretendard-Regular',
+};
+
+const swiftWeightMap = {
+  '700': '.bold',
+  '600': '.semibold',
+  '400': '.regular',
+};
+
+StyleDictionary.registerFormat({
+  name: 'ios/swift-typography-semantic',
+  format: ({ dictionary }) => {
+    let output = fileHeader('Typography.swift');
+    output += '// MARK: - Semantic Typography\n\n';
+    output += 'public enum Typography {\n';
+
+    for (const token of dictionary.allTokens) {
+      const cat = token.path[1];
+      const num = token.path[2];
+      const name = `${cat}${num}`;
+      const val = token.$value ?? token.value;
+
+      const weightKey = String(toNumber(val.fontWeight));
+      const fontSize = toNumber(val.fontSize);
+      const lineHeight = toNumber(val.lineHeight);
+      const letterSpacingPercent = toNumber(val.letterSpacing);
+      const letterSpacing = parseFloat((fontSize * (letterSpacingPercent / 100)).toFixed(2));
+
+      const fontName = fontNameMap[weightKey] ?? 'Pretendard-Regular';
+      const swiftWeight = swiftWeightMap[weightKey] ?? '.regular';
+
+      output += `    public static let ${name} = MDSFont(\n`;
+      output += `        font: UIFont(name: "${fontName}", size: ${fontSize}) ?? .systemFont(ofSize: ${fontSize}, weight: ${swiftWeight}),\n`;
+      output += `        lineHeight: ${lineHeight},\n`;
+      output += `        letterSpacing: ${letterSpacing}\n`;
+      output += `    )\n`;
+    }
+
+    output += '}\n';
+    return output;
+  }
+});
+
 const sd = new StyleDictionary({
   usesDtcg: true,
   log: { warnings: 'disabled' },
@@ -92,12 +138,23 @@ const sd = new StyleDictionary({
         {
           destination: 'BaseTypography.swift',
           format: 'ios/swift-typography',
-          filter: (token) => token.path[0] === 'typography'
+          filter: (token) => token.path[0] === 'typography' && typeof (token.$value ?? token.value) !== 'object'
         },
         {
           destination: 'BaseSpacing.swift',
           format: 'ios/swift-spacing',
           filter: (token) => token.path[0] === 'spacing'
+        }
+      ]
+    },
+    swiftSemantic: {
+      transforms: [],
+      buildPath: 'MDS/Sources/MDS/Tokens/',
+      files: [
+        {
+          destination: 'Typography.swift',
+          format: 'ios/swift-typography-semantic',
+          filter: (token) => token.path[0] === 'typography' && typeof (token.$value ?? token.value) === 'object'
         }
       ]
     }

--- a/tokens/semantic/typography.json
+++ b/tokens/semantic/typography.json
@@ -1,0 +1,138 @@
+{
+  "typography": {
+    "heading": {
+      "1": {
+        "$value": {
+          "fontWeight": "{typography.weight.bold}",
+          "fontSize": "{typography.size.32}",
+          "lineHeight": "{typography.lineHeight.48}",
+          "letterSpacing": "{typography.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "2": {
+        "$value": {
+          "fontWeight": "{typography.weight.bold}",
+          "fontSize": "{typography.size.24}",
+          "lineHeight": "{typography.lineHeight.36}",
+          "letterSpacing": "{typography.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "3": {
+        "$value": {
+          "fontWeight": "{typography.weight.bold}",
+          "fontSize": "{typography.size.20}",
+          "lineHeight": "{typography.lineHeight.30}",
+          "letterSpacing": "{typography.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "4": {
+        "$value": {
+          "fontWeight": "{typography.weight.bold}",
+          "fontSize": "{typography.size.16}",
+          "lineHeight": "{typography.lineHeight.24}",
+          "letterSpacing": "{typography.letterSpacing.wide}"
+        },
+        "$type": "typography"
+      }
+    },
+    "title": {
+      "1": {
+        "$value": {
+          "fontWeight": "{typography.weight.semibold}",
+          "fontSize": "{typography.size.28}",
+          "lineHeight": "{typography.lineHeight.42}",
+          "letterSpacing": "{typography.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "2": {
+        "$value": {
+          "fontWeight": "{typography.weight.semibold}",
+          "fontSize": "{typography.size.24}",
+          "lineHeight": "{typography.lineHeight.36}",
+          "letterSpacing": "{typography.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "3": {
+        "$value": {
+          "fontWeight": "{typography.weight.semibold}",
+          "fontSize": "{typography.size.20}",
+          "lineHeight": "{typography.lineHeight.30}",
+          "letterSpacing": "{typography.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "4": {
+        "$value": {
+          "fontWeight": "{typography.weight.semibold}",
+          "fontSize": "{typography.size.16}",
+          "lineHeight": "{typography.lineHeight.24}",
+          "letterSpacing": "{typography.letterSpacing.wide}"
+        },
+        "$type": "typography"
+      }
+    },
+    "body": {
+      "1": {
+        "$value": {
+          "fontWeight": "{typography.weight.regular}",
+          "fontSize": "{typography.size.16}",
+          "lineHeight": "{typography.lineHeight.26}",
+          "letterSpacing": "{typography.letterSpacing.wide}"
+        },
+        "$type": "typography"
+      },
+      "2": {
+        "$value": {
+          "fontWeight": "{typography.weight.regular}",
+          "fontSize": "{typography.size.14}",
+          "lineHeight": "{typography.lineHeight.22}",
+          "letterSpacing": "{typography.letterSpacing.wide}"
+        },
+        "$type": "typography"
+      }
+    },
+    "label": {
+      "1": {
+        "$value": {
+          "fontWeight": "{typography.weight.semibold}",
+          "fontSize": "{typography.size.18}",
+          "lineHeight": "{typography.lineHeight.24}",
+          "letterSpacing": "{typography.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "2": {
+        "$value": {
+          "fontWeight": "{typography.weight.semibold}",
+          "fontSize": "{typography.size.16}",
+          "lineHeight": "{typography.lineHeight.22}",
+          "letterSpacing": "{typography.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "3": {
+        "$value": {
+          "fontWeight": "{typography.weight.semibold}",
+          "fontSize": "{typography.size.14}",
+          "lineHeight": "{typography.lineHeight.18}",
+          "letterSpacing": "{typography.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "4": {
+        "$value": {
+          "fontWeight": "{typography.weight.semibold}",
+          "fontSize": "{typography.size.12}",
+          "lineHeight": "{typography.lineHeight.16}",
+          "letterSpacing": "{typography.letterSpacing.default}"
+        },
+        "$type": "typography"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 작업 요약
- 시맨틱 타이포그래피 토큰을 추가했습니다.
- CI가 `Tokens/Typography.swift` 자동 생성하도록 `build.js` 수정
- MDSFont 타입 추가
- `setTypography(_:) extension` 추가
- .github/workflows/style-dictionary.yml: Typography.swift를 자동 커밋 대상에 포함하도록 수정

## PR Point
### 사용 방법
앱 프로젝트 내에서 사용하는 방법은 아래와 같습니다.

```swift
import MDS

label.setTypography(Typography.heading1)
```
- `setTypography`는 `font`, `lineHeight`, `letterSpacing`을 NSAttributedString으로 한 번에 적용합니다.

### 폴더 구조 결정
새로 추가된 파일은 아래와 같습니다.
| 파일명 | 역할 |
| :--: | :--: |
| `MDSFont.swift` |  타입 정의 |
| `Typography.swift`   | 시맨틱 토큰 (CI 자동 생성) |
| `UILabel+Typography.swift` | UIKit extension |

레이어별 책임을 다음과 같이 분리했습니다.

- `MDSFont`는 Tokens 계층이 사용하는 타입으로, **원시타입을 정의한 것**이기 때문에 `Foundation`이 적합하다고 생각했습니다.
- `Typography.swift`는 CI에 의해 생성/수정되는 파일로 Foundation의 원시값을 조합해 heading1, body2 같은 `시맨틱 토큰으로 만드는 레이어`이기 때문에 `Tokens/`에 두었습니다.
- `UILabel+Typography.swift`는 컴포넌트의 일부이기 때문에 **UIKit를 의존하게 됩니다.** 따라서 Tokens이나 Foundation **디렉토리가 UIKit에 의존하게 되는 것을 막기 위해** `Components`에 두었습니다.

의존성 방향은 Components → Tokens → Foundation 단방향으로 유지되어 향후 멀티 모듈 전환 시에도 모듈 간의 경계가 변하지 않도록 구성했습니다.

더 좋은 폴더링 방법이 있다면 리뷰 부탁드립니다!

## 작업 흐름 정리
1. token-sync에 JSON push
2. GitHub Actions: npm run build
3. Typography.swift 생성 및 auto-commit
4. token-sync -> default PR 자동 생성

close #14 