### PR TITLE
[Feat] #19 - Semantic typography에서 BaseTypography 참조 사용

### DIFF
--- a/build.js
+++ b/build.js
@@ -125,11 +125,18 @@ const swiftWeightMap = {
   '400': '.regular',
 };
 
-const refToBaseTypography = (ref) => {
-  const path = ref.slice(1, -1).split('.');
-  // e.g. '{typography.base.size.t32}' → ['typography', 'base', 'size', 't32']
-  const cat = capitalize(path[2]);
-  const key = path[3] === 'default' ? '`default`' : path[3];
+const TYPOGRAPHY_REF_PATTERN = /^\{typography\.base\.([^.]+)\.([^.}]+)\}$/;
+
+const refToBaseTypography = (ref, tokenPath, fieldName) => {
+  const match = typeof ref === 'string' && ref.match(TYPOGRAPHY_REF_PATTERN);
+  if (!match) {
+    throw new Error(
+      `Token "${tokenPath}": "${fieldName}" 참조가 유효하지 않음 (값: ${JSON.stringify(ref)})\n` +
+      `  예상 형식: {typography.base.<category>.<key>}`
+    );
+  }
+  const cat = capitalize(match[1]);
+  const key = match[2] === 'default' ? '`default`' : match[2];
   return `BaseTypography.${cat}.${key}`;
 };
 
@@ -151,9 +158,10 @@ StyleDictionary.registerFormat({
       const fontName = fontNameMap[weightKey] ?? 'Pretendard-Regular';
       const swiftWeight = swiftWeightMap[weightKey] ?? '.regular';
 
-      const fontSizeRef = refToBaseTypography(orig.fontSize);
-      const lineHeightRef = refToBaseTypography(orig.lineHeight);
-      const letterSpacingRef = refToBaseTypography(orig.letterSpacing);
+      const tokenPath = token.path.join('.');
+      const fontSizeRef = refToBaseTypography(orig.fontSize, tokenPath, 'fontSize');
+      const lineHeightRef = refToBaseTypography(orig.lineHeight, tokenPath, 'lineHeight');
+      const letterSpacingRef = refToBaseTypography(orig.letterSpacing, tokenPath, 'letterSpacing');
 
       output += `    public static let ${name} = MDSFont(\n`;
       output += `        font: UIFont(name: "${fontName}", size: ${fontSizeRef}) ?? .systemFont(ofSize: ${fontSizeRef}, weight: ${swiftWeight}),\n`;

--- a/build.js
+++ b/build.js
@@ -125,6 +125,14 @@ const swiftWeightMap = {
   '400': '.regular',
 };
 
+const refToBaseTypography = (ref) => {
+  const path = ref.slice(1, -1).split('.');
+  // e.g. '{typography.base.size.t32}' → ['typography', 'base', 'size', 't32']
+  const cat = capitalize(path[2]);
+  const key = path[3] === 'default' ? '`default`' : path[3];
+  return `BaseTypography.${cat}.${key}`;
+};
+
 StyleDictionary.registerFormat({
   name: 'ios/swift-typography-semantic',
   format: ({ dictionary }) => {
@@ -137,20 +145,20 @@ StyleDictionary.registerFormat({
       const num = token.path[2];
       const name = `${cat}${num}`;
       const val = token.$value ?? token.value;
+      const orig = token.original.$value ?? token.original.value;
 
       const weightKey = String(toNumber(val.fontWeight));
-      const fontSize = toNumber(val.fontSize);
-      const lineHeight = toNumber(val.lineHeight);
-      const letterSpacingPercent = toNumber(val.letterSpacing);
-      const letterSpacing = parseFloat((fontSize * (letterSpacingPercent / 100)).toFixed(2));
-
       const fontName = fontNameMap[weightKey] ?? 'Pretendard-Regular';
       const swiftWeight = swiftWeightMap[weightKey] ?? '.regular';
 
+      const fontSizeRef = refToBaseTypography(orig.fontSize);
+      const lineHeightRef = refToBaseTypography(orig.lineHeight);
+      const letterSpacingRef = refToBaseTypography(orig.letterSpacing);
+
       output += `    public static let ${name} = MDSFont(\n`;
-      output += `        font: UIFont(name: "${fontName}", size: ${fontSize}) ?? .systemFont(ofSize: ${fontSize}, weight: ${swiftWeight}),\n`;
-      output += `        lineHeight: ${lineHeight},\n`;
-      output += `        letterSpacing: ${letterSpacing}\n`;
+      output += `        font: UIFont(name: "${fontName}", size: ${fontSizeRef}) ?? .systemFont(ofSize: ${fontSizeRef}, weight: ${swiftWeight}),\n`;
+      output += `        lineHeight: ${lineHeightRef},\n`;
+      output += `        letterSpacing: ${fontSizeRef} * (${letterSpacingRef} / 100)\n`;
       output += `    )\n`;
     }
 

--- a/tokens/semantic/typography.json
+++ b/tokens/semantic/typography.json
@@ -1,0 +1,138 @@
+{
+  "typography": {
+    "heading": {
+      "1": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.bold}",
+          "fontSize": "{typography.base.size.t32}",
+          "lineHeight": "{typography.base.lineHeight.t48}",
+          "letterSpacing": "{typography.base.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "2": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.bold}",
+          "fontSize": "{typography.base.size.t24}",
+          "lineHeight": "{typography.base.lineHeight.t36}",
+          "letterSpacing": "{typography.base.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "3": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.bold}",
+          "fontSize": "{typography.base.size.t20}",
+          "lineHeight": "{typography.base.lineHeight.t30}",
+          "letterSpacing": "{typography.base.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "4": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.bold}",
+          "fontSize": "{typography.base.size.t16}",
+          "lineHeight": "{typography.base.lineHeight.t24}",
+          "letterSpacing": "{typography.base.letterSpacing.wide}"
+        },
+        "$type": "typography"
+      }
+    },
+    "title": {
+      "1": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.semibold}",
+          "fontSize": "{typography.base.size.t28}",
+          "lineHeight": "{typography.base.lineHeight.t42}",
+          "letterSpacing": "{typography.base.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "2": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.semibold}",
+          "fontSize": "{typography.base.size.t24}",
+          "lineHeight": "{typography.base.lineHeight.t36}",
+          "letterSpacing": "{typography.base.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "3": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.semibold}",
+          "fontSize": "{typography.base.size.t20}",
+          "lineHeight": "{typography.base.lineHeight.t30}",
+          "letterSpacing": "{typography.base.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "4": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.semibold}",
+          "fontSize": "{typography.base.size.t16}",
+          "lineHeight": "{typography.base.lineHeight.t24}",
+          "letterSpacing": "{typography.base.letterSpacing.wide}"
+        },
+        "$type": "typography"
+      }
+    },
+    "body": {
+      "1": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.regular}",
+          "fontSize": "{typography.base.size.t16}",
+          "lineHeight": "{typography.base.lineHeight.t26}",
+          "letterSpacing": "{typography.base.letterSpacing.wide}"
+        },
+        "$type": "typography"
+      },
+      "2": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.regular}",
+          "fontSize": "{typography.base.size.t14}",
+          "lineHeight": "{typography.base.lineHeight.t22}",
+          "letterSpacing": "{typography.base.letterSpacing.wide}"
+        },
+        "$type": "typography"
+      }
+    },
+    "label": {
+      "1": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.semibold}",
+          "fontSize": "{typography.base.size.t18}",
+          "lineHeight": "{typography.base.lineHeight.t24}",
+          "letterSpacing": "{typography.base.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "2": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.semibold}",
+          "fontSize": "{typography.base.size.t16}",
+          "lineHeight": "{typography.base.lineHeight.t22}",
+          "letterSpacing": "{typography.base.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "3": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.semibold}",
+          "fontSize": "{typography.base.size.t14}",
+          "lineHeight": "{typography.base.lineHeight.t18}",
+          "letterSpacing": "{typography.base.letterSpacing.default}"
+        },
+        "$type": "typography"
+      },
+      "4": {
+        "$value": {
+          "fontWeight": "{typography.base.weight.semibold}",
+          "fontSize": "{typography.base.size.t12}",
+          "lineHeight": "{typography.base.lineHeight.t16}",
+          "letterSpacing": "{typography.base.letterSpacing.default}"
+        },
+        "$type": "typography"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#19

## 🌱 PR Point
## **1. tokens/semantic/typography.json 재생성**
- 수정된 base token을 사용하도록 `semantic/typography.json` 재생성

### **2. build.js에서 typography-semantic 포맷 수정**
- raw 숫자 대신 `BaseTypography` enum 참조를 사용하도록 변경
- `token.original.$value`의 참조 문자열을 파싱하는 `refToBaseTypography` 함수 추가
```
"{typography.base.size.t32}" → BaseTypography.Size.t32
"{typography.base.lineHeight.t48}" → BaseTypography.LineHeight.t48
"{typography.base.letterSpacing.default}" →  BaseTypography.LetterSpacing.`default`
```
- 하드코딩 맵 없이 JSON 토큰 정보로부터 직접 참조 도출

**생성 결과 예시**
```swift
public static let heading1 = MDSFont(
    font: UIFont(name: "Pretendard-Bold", size: BaseTypography.Size.t32) ?? .systemFont(ofSize: BaseTypography.Size.t32, weight: .bold),
    lineHeight: BaseTypography.LineHeight.t48,
    letterSpacing: BaseTypography.Size.t32 * (BaseTypography.LetterSpacing.`default` / 100)
)
```
- Pretendard에서 SUIT 전환은 #20 에서 진행할 예정

## 📌 참고 사항
- 폰트 이름(Pretendard)은 이슈 #20에서 SUIT로 변경 예정

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #19