### PR TITLE
[Fix] #42 - Swift 빌드 검증 및 Swift 6 동시성 오류 수정

### DIFF
--- a/.github/workflows/style-dictionary.yml
+++ b/.github/workflows/style-dictionary.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     permissions:
       contents: write
       pull-requests: write
@@ -99,6 +99,14 @@ jobs:
 
           fs.writeFileSync('/tmp/token_diff.md', table);
           EOF
+
+      - name: Validate Swift build
+        run: |
+          cd MDS && xcodebuild build \
+            -scheme MDS \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            | xcpretty || exit 1
 
       - name: Commit generated Swift files
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/style-dictionary.yml
+++ b/.github/workflows/style-dictionary.yml
@@ -101,7 +101,9 @@ jobs:
           EOF
 
       - name: Validate Swift build
+        shell: bash
         run: |
+          set -o pipefail
           cd MDS && xcodebuild build \
             -scheme MDS \
             -destination 'generic/platform=iOS Simulator' \

--- a/MDS/Package.swift
+++ b/MDS/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "MDS",
+    platforms: [
+        .iOS(.v16)
+    ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/MDS/Sources/MDS/Foundation/Base/FontLoader.swift
+++ b/MDS/Sources/MDS/Foundation/Base/FontLoader.swift
@@ -8,6 +8,7 @@
 import CoreText
 import Foundation
 
+@MainActor
 internal enum FontLoader {
     private static var isRegistered = false
 

--- a/MDS/Sources/MDS/Foundation/MDSFont.swift
+++ b/MDS/Sources/MDS/Foundation/MDSFont.swift
@@ -5,6 +5,8 @@
 
 import UIKit
 
+/// `@unchecked` Sendable conformance: UIFont는 불변 객체로서 Apple 문서에서 명시적으로
+/// 다중 스레드 안전성을 보장하며, 모든 저장 프로퍼티(UIFont, CGFloat)는 불변입니다.
 public struct MDSFont: @unchecked Sendable {
     public let font: UIFont
     public let lineHeight: CGFloat

--- a/MDS/Sources/MDS/Foundation/MDSFont.swift
+++ b/MDS/Sources/MDS/Foundation/MDSFont.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public struct MDSFont {
+public struct MDSFont: @unchecked Sendable {
     public let font: UIFont
     public let lineHeight: CGFloat
     public let letterSpacing: CGFloat

--- a/build.js
+++ b/build.js
@@ -252,7 +252,7 @@ StyleDictionary.registerFormat({
 
         // state enum
         for (const [base, states] of Object.entries(stateGroups)) {
-          const enumName = capitalize(toSwiftName(base));
+          const enumName = toSwiftName(capitalize(base));
           output += `\n            public enum ${enumName} {\n`;
           for (const [state, token] of Object.entries(states)) {
             const rawValue = token.original?.$value ?? token.original?.value ?? token.$value ?? token.value;


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#42-swift-build-validation

## 🌱 PR Point

### 1. CI 빌드 검증 수정

**AS-IS**
- `ubuntu-latest` runner에서 `swift build`로 빌드 검증
- `swift build`는 항상 macOS 호스트를 타겟으로 빌드하기 때문에 UIKit 모듈을 찾지 못해 빌드 자체가 불가능한 상태였음

**TO-BE**
- `macos-latest` runner에서 `xcodebuild -destination 'generic/platform=iOS Simulator'`로 교체
- `Package.swift`에 `platforms: [.iOS(.v16)]` 추가하여 iOS 타겟임을 명시
- iOS SDK가 있는 환경에서 실제 사용 환경과 동일하게 검증

---

### 2. xcodebuild 빌드 실패가 파이프라인에서 묻히는 문제 수정

**AS-IS**
- `xcodebuild ... | xcpretty || exit 1` 구성에서 bash 기본 동작은 파이프의 마지막 명령(xcpretty)의 종료 코드만 반환
- xcpretty는 로그 포맷팅 도구라 항상 exit 0을 반환하므로, xcodebuild가 실패해도 `|| exit 1`이 트리거되지 않아 빌드 실패가 CI를 통과하는 문제

**TO-BE**
- `shell: bash` 명시로 GitHub Actions가 `-eo pipefail` 옵션을 포함해 실행하도록 변경
- `set -o pipefail` 추가로 파이프 중 하나라도 실패하면 전체 파이프라인 종료 코드가 실패로 처리됨

---

### 3. MDSFont — `@unchecked Sendable`

**AS-IS**
- `MDSFont`가 `Sendable` 미준수 상태
- Swift 6에서 `MDSFont`를 격리 도메인 간 전달 시 `non-'Sendable' type` 컴파일 에러 발생

**TO-BE**
- `@unchecked Sendable` 추가
- `UIFont`는 class 타입이라 컴파일러가 자동으로 Sendable을 증명할 수 없음
- 모든 프로퍼티(`font`, `lineHeight`, `letterSpacing`)는 생성 후 불변(`let`)이므로 동시 접근이 안전 — 개발자가 직접 보장

**`@MainActor`가 아닌 `@unchecked Sendable`을 선택한 이유**
- `MDSFont`는 `UILabel`, `UIButton` 같은 UI 컴포넌트가 아니라 폰트 정보를 담는 **데이터 타입**
- `@MainActor`는 "이 타입은 메인 스레드에서만 써야 한다"는 의미인데, `MDSFont`는 어떤 폰트를 어떻게 쓸지에 대한 명세(spec)에 가까움
- UI에 실제로 적용하는 건 이 값을 받아서 쓰는 쪽(`label.font = ...`)의 책임이므로 `MDSFont` 자체를 메인 스레드에 귀속시킬 이유가 없음
- `CGSize`, `UIEdgeInsets`처럼 어느 스레드에서든 자유롭게 들고 다닐 수 있는 값으로 설계

---

### 4. FontLoader — `@MainActor`

**AS-IS**
- `isRegistered`가 `private static var`로 선언
- Swift 6에서 mutable global state는 여러 Task가 동시 접근 시 데이터 레이스 위험으로 컴파일 에러 발생

**TO-BE**
- `FontLoader` 전체에 `@MainActor` 추가
- `registerIfNeeded()`는 UIKit 초기화 컨텍스트(메인 스레드)에서만 호출되므로 `@MainActor` 격리가 의미적으로 적합
- `nonisolated(unsafe)` 대신 `@MainActor`를 선택한 이유: 실제 호출 시점이 메인 스레드로 보장되므로 불필요한 `unsafe` 없이 컴파일러가 안전성을 검증할 수 있음

---

### 5. build.js — SemanticColor `invalid redeclaration` 수정

**AS-IS**
- `capitalize(toSwiftName(base))`로 state 그룹 enum 이름 생성
- `toSwiftName`이 먼저 실행되어 `default` → `` `default` ``(backtick 포함)로 변환한 뒤 `capitalize`가 첫 글자인 backtick을 대문자화하려다 무력화됨
- 결과적으로 같은 스코프에 `static let \`default\``(프로퍼티)와 `enum \`default\``(타입)이 동시 생성 → Swift `invalid redeclaration` 에러

**TO-BE**
- `toSwiftName(capitalize(base))`로 순서 변경
- `capitalize`가 먼저 실행되어 `default` → `Default`로 변환 후 `toSwiftName`이 keyword 여부를 검사
- `Default`는 Swift 예약어가 아니므로 backtick 없이 `enum Default`로 생성 → 프로퍼티 `` `default` ``와 이름이 달라 충돌 없음

## 📌 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷

해당 없음

## 📮 관련 이슈
- Resolved: #42