### PR TITLE
[Docs] #45 - README 및 토큰 가이드 문서화

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,19 +96,47 @@ iOS 앱 디자인 시스템을 웹 브라우저에서 확인하는 것은 실제
 
 ## 워크플로우
 
+### 자동화가 필요했던 이유
+
+1. 토큰을 수정할 때마다 Style Dictionary를 수동으로 실행해 각 플랫폼 코드로 변환해야 해 번거로움
+2. Token Studio 무료 플랜은 기간 제한이 있어 장기 운영이 불가 → Figma 플러그인에서 JSON 추출까지 자동화 필요
+
+### 목표 구조
+
 ```
-Figma 변경
-    ↓
+Figma 플러그인
+    ├── 토큰 등록 (Base / Semantic 분류, 토큰 간 참조)
+    └── JSON으로 변환 → 서버로 전송
+          ↓
+    서버에서 JSON 수신
+    → GitHub API로 브랜치 생성 + PR 자동 오픈
+          ↓
+    개발자 PR 리뷰 & 머지
+          ↓
+    GitHub Actions 실행
+    ├── Style Dictionary: JSON → 각 플랫폼 코드 자동 변환
+    └── 패키지 재배포
+          ↓
+    Slack 알림
+```
+
+### 현재 구조 (서버 연동 전)
+
+```
 tokens/ JSON 수정 후 token-sync 브랜치에 push
     ↓
 GitHub Actions 실행
     ├── Style Dictionary: JSON → Swift 파일 자동 생성
-    ├── xcodebuild: iOS Simulator 빌드 검증 (pipefail 적용)
+    ├── xcodebuild: iOS Simulator 빌드 검증
     └── 변경된 Swift 파일 커밋 + default로 PR 생성
     ↓
 PR 리뷰 & 머지 → 태그 → SPM 배포
 ```
 
-> 향후 Figma 서버 연동 시 `repository_dispatch` 이벤트로 전환 예정.
+> **향후 계획:** Figma 서버 연동 시 `repository_dispatch` 이벤트로 전환 예정.
 > 토큰 변경이 감지될 때만 `token-sync/날짜` 에페머럴 브랜치를 생성해
 > 장기 브랜치의 rebase 비용을 제거합니다.
+
+## 토큰 상세 문서
+
+토큰 구조, 네이밍 컨벤션, Base/Semantic 설계 이유에 대한 자세한 내용은 [토큰 가이드](docs/tokens.md)를 참고하세요.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,114 @@
-# SOPT-iOS-MDS
-Makers iOS 디자인시스템 레포지토리입니다.
+# MDS — Makers Design System
+
+SOPT Makers의 iOS 디자인 시스템 라이브러리입니다.
+Style Dictionary 기반으로 디자인 토큰을 Swift 코드로 자동 변환하며, Swift 6 strict concurrency를 완전 지원합니다.
+
+## 요구사항
+
+- iOS 16+
+- Swift 6
+
+## 설치
+
+Xcode → File → Add Package Dependencies에서 아래 URL을 입력합니다.
+
+```
+https://github.com/sopt-makers/SOPT-iOS-MDS
+```
+
+## 시작하기
+
+앱 시작 시점에 SUIT 폰트를 한 번 등록합니다.
+
+```swift
+// AppDelegate 또는 @main
+@MainActor
+func application(_ application: UIApplication,
+                 didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    FontLoader.registerIfNeeded()
+    return true
+}
+```
+
+## 사용법
+
+### Typography
+
+`UILabel.setTypography(_:)`를 사용하면 font, lineHeight, letterSpacing이 한 번에 적용됩니다.
+
+```swift
+label.setTypography(Typography.heading1)
+label.setTypography(Typography.body2)
+```
+
+### SemanticColor
+
+```swift
+view.backgroundColor = SemanticColor.Bg.Neutral.default
+label.textColor = SemanticColor.Fg.Neutral.default
+view.layer.borderColor = SemanticColor.Stroke.Brand.default.cgColor
+```
+
+hover, pressed, disabled 등 상태값이 있는 토큰은 중첩 enum으로 접근합니다.
+
+```swift
+button.backgroundColor = SemanticColor.Bg.Secondary.Default.hover
+button.backgroundColor = SemanticColor.Bg.Danger.Default.pressed
+```
+
+## 토큰 구조
+
+토큰은 Base와 Semantic 두 레이어로 구성됩니다.
+
+| 레이어 | 접근 | 예시 | 역할 |
+|--------|------|------|------|
+| Base | `internal` | `BaseColor.gray600` | 원시값 정의. 외부에서 직접 사용 불가 |
+| Semantic | `public` | `SemanticColor.Bg.Neutral.default` | 의미 기반 사용 API |
+
+Semantic 토큰은 항상 Base 토큰을 참조합니다. 디자이너가 Figma에서 토큰을 수정하면 JSON → Swift 변환이 자동으로 이루어집니다.
+
+## 의사결정 기록
+
+### Base 레이어에 prefix를 붙인 이유
+
+디자이너가 정의한 토큰 위계는 `Typography.size.16`이지만, Swift에서 숫자는 식별자의 시작이 될 수 없어 그대로 사용할 수 없습니다. 카테고리명을 반복해 `Typography.size.size16`으로 해결할 수도 있지만 위계 정보가 두 번 중복됩니다. Seed Design, TDS 등을 참고해 Base prefix를 붙이는 방식으로 중복 없이 해결했습니다.
+
+반면 Semantic 토큰(`Typography.heading1`, `SemanticColor.Bg.Neutral.default`)은 그 자체가 디자인 요소명으로서 의미를 담고 있어 prefix가 불필요합니다.
+
+또한 Base 레이어는 `internal`로, Semantic 레이어는 `public`으로 접근을 제한해 네이밍과 접근제어가 같은 의도를 표현합니다.
+
+### Storybook을 사용하지 않은 이유
+
+iOS 앱 디자인 시스템을 웹 브라우저에서 확인하는 것은 실제 사용 맥락(네이티브 앱)과 달라 컴포넌트의 실제 동작을 정확히 검증하기 어렵다고 판단했습니다. iOS 생태계에서 Storybook은 웹만큼 성숙하지 않아 별도 앱 타겟을 유지하는 비용도 큽니다. 대신 xcodebuild CI 검증으로 빌드 안전성을 확보했습니다.
+
+### Style Dictionary를 도입한 이유
+
+디자인 토큰을 JSON으로 단일 정의(SSOT)하면 웹, Android, iOS 모두가 동일한 소스에서 각 플랫폼에 맞게 코드를 자동 생성할 수 있습니다. Figma 변경이 생겼을 때 수동 변환 과정 없이 반영되어 휴먼 에러를 제거합니다.
+
+### Swift 6 strict concurrency 대응
+
+| 타입 | 선택 | 이유 |
+|------|------|------|
+| `MDSFont` | `@unchecked Sendable` | `UIFont`는 class 타입이라 컴파일러가 Sendable을 자동 증명할 수 없음. 모든 프로퍼티가 `let`이고 생성 후 불변이므로 개발자가 직접 보장 |
+| `FontLoader` | `@MainActor` | `isRegistered`가 mutable static var. `registerIfNeeded()`는 UIKit 초기화(메인 스레드)에서만 호출되므로 `@MainActor` 격리가 의미적으로 적합 |
+
+`MDSFont`에 `@MainActor`가 아닌 `@unchecked Sendable`을 선택한 이유: `MDSFont`는 폰트 명세를 담는 데이터 타입으로 `CGSize`, `UIEdgeInsets`에 가깝습니다. UI를 직접 건드리는 타입이 아니므로 메인 스레드에 귀속시키지 않고 어느 스레드에서든 자유롭게 참조할 수 있도록 설계했습니다.
+
+## 워크플로우
+
+```
+Figma 변경
+    ↓
+tokens/ JSON 수정 후 token-sync 브랜치에 push
+    ↓
+GitHub Actions 실행
+    ├── Style Dictionary: JSON → Swift 파일 자동 생성
+    ├── xcodebuild: iOS Simulator 빌드 검증 (pipefail 적용)
+    └── 변경된 Swift 파일 커밋 + default로 PR 생성
+    ↓
+PR 리뷰 & 머지 → 태그 → SPM 배포
+```
+
+> 향후 Figma 서버 연동 시 `repository_dispatch` 이벤트로 전환 예정.
+> 토큰 변경이 감지될 때만 `token-sync/날짜` 에페머럴 브랜치를 생성해
+> 장기 브랜치의 rebase 비용을 제거합니다.

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -1,0 +1,200 @@
+# 토큰 가이드
+
+## 토큰이란?
+
+**디자인 의사결정**을 이름 있는 변수로 **코드화**한 것으로, 디자이너와 개발자가 동일한 기준으로 소통하기 위한 공통 언어입니다.
+
+- 디자인과 구현 사이의 기준을 일치시켜 의도한 결과가 동일하게 구현되도록 합니다.
+- 값을 직접 쓰지 않고 참조 구조(Base → Semantic)로 관리해 스타일 변경을 일관되게 적용할 수 있습니다.
+- 디자이너와 개발자가 같은 이름으로 소통해 커뮤니케이션 오차를 줄입니다.
+
+## 구조
+
+토큰은 **Base → Semantic** 두 계층으로 구성됩니다.
+
+| 레이어 | 접근 | 역할 |
+|--------|------|------|
+| Base | `internal` | 원시값 정의. 직접 사용 불가 (spacing 제외) |
+| Semantic | `public` | 사용 목적과 맥락을 담은 실사용 API |
+
+**Semantic 토큰만 직접 참조(사용)할 수 있습니다.** 예외적으로 spacing은 Base 토큰 사용이 가능합니다.
+
+- Semantic 토큰은 사용 목적을 이름에 담고 있어 일관된 스타일을 유지할 수 있습니다.
+- Base 토큰은 원시값에 단순 이름만 붙인 것이라 값이 변경될 때 영향 범위를 추적하기 어렵습니다.
+- Spacing은 다양한 해상도 환경에 유연하게 대응해야 하고 적용 맥락이 광범위해, 의미보다 수치 기반 시스템으로 범용성을 확보합니다.
+
+---
+
+## Color
+
+### Base token
+
+서비스에서 활용할 수 있는 원시 색상 값을 정의합니다.
+
+```
+color.base.{palette}{level}
+```
+
+| Base token | Raw value |
+|------------|-----------|
+| color.base.gray0 | #FFFFFF |
+| color.base.orange400 | #F77234 |
+
+### Semantic token
+
+UI에 직접 사용되는 의미 기반 색상입니다.
+
+```
+color.{target}.{role}.{emphasis}.{state}
+```
+
+| 레벨 | 설명 | 값 |
+|------|------|-----|
+| target | 적용 대상 | `bg` / `fg` / `stroke` |
+| role | 의미 역할 | `brand` / `secondary` / `neutral` / `success` / `attention` / `danger` / `information` / `dim` |
+| emphasis | 강조 수준 | `bold` / `default` / `subtle` / `ghost` / `inverse` |
+| state | 상태 (선택) | `hover` / `pressed` / `focused` / `disabled` |
+
+**state만 선택적으로 사용할 수 있으며, 나머지 레벨은 모두 필수입니다.**
+
+#### target
+
+- `bg`: 컴포넌트나 페이지의 면을 채우는 배경색
+- `fg`: 배경 위에 올라가는 텍스트, 아이콘 색상
+- `stroke`: 보더, 구분선 등 외곽선 색상
+
+#### role
+
+- `brand`: 서비스 아이덴티티를 나타내는 브랜드 색상
+- `secondary`: 브랜드 다음 위계의 색상
+- `neutral`: 일반 정보나 UI 전반에 사용되는 무채색
+- `success`: 완료, 긍정적인 결과를 나타내는 색상
+- `attention`: 주의, 경고 등 사용자 확인이 필요한 정보
+- `danger`: 경고, 삭제 등 위험도가 높은 상태
+- `information`: 안내, 팁 등 정보성 맥락
+- `dim`: modal 뒤에 깔리는 오버레이
+
+#### emphasis
+
+- `bold`: 가장 높은 대비, 강한 시선 집중
+- `default` → `subtle` → `ghost` 순으로 강도 감소
+- `inverse`: 배경색과 반전된 색상
+
+| Base token | Semantic token | Raw value |
+|------------|---------------|-----------|
+| color.base.orange400 | color.bg.brand.default | #F77234 |
+
+---
+
+## Typography
+
+### Base token
+
+weight, size, lineHeight, letterSpacing을 각각 분리 관리합니다.
+
+#### weight
+
+```
+typography.base.weight.{level}
+```
+
+| Base token | Raw value |
+|------------|-----------|
+| typography.base.weight.bold | 700 |
+| typography.base.weight.semibold | 600 |
+| typography.base.weight.regular | 400 |
+
+#### size
+
+```
+typography.base.size.t{level}
+```
+
+| Base token | Raw value |
+|------------|-----------|
+| typography.base.size.t12 | 12px |
+| typography.base.size.t16 | 16px |
+
+#### lineHeight
+
+```
+typography.base.lineHeight.t{level}
+```
+
+| Base token | Raw value |
+|------------|-----------|
+| typography.base.lineHeight.t16 | 16px |
+| typography.base.lineHeight.t24 | 24px |
+
+#### letterSpacing
+
+```
+typography.base.letterSpacing.{level}
+```
+
+| Base token | Raw value |
+|------------|-----------|
+| typography.base.letterSpacing.wide | -1.5% |
+| typography.base.letterSpacing.default | -2.0% |
+
+> weight와 letterSpacing은 수치 대신 의미 기반 이름(bold, wide 등)을 사용합니다. 수치 자체보다 상대적인 역할과 사용 의도를 더 직관적으로 전달하기 위함입니다.
+
+### Semantic token
+
+Base 토큰의 weight, size, lineHeight, letterSpacing을 묶어 하나의 텍스트 스타일로 정의합니다.
+
+```
+typography.{role}{level}
+```
+
+- `heading`: 페이지의 핵심 제목
+- `title`: 섹션이나 컴포넌트의 제목
+- `body`: 본문 텍스트
+- `label`: 버튼, 태그, 입력 필드 등 UI 요소에 부착되는 짧은 텍스트
+
+level은 동일 role 안에서의 시각적 위계를 의미하며, 숫자가 작을수록 더 높은 강조 수준입니다.
+
+| Semantic token | Base token | Raw value |
+|----------------|------------|-----------|
+| typography.heading1 | typography.base.weight.bold | 700 |
+| | typography.base.size.t32 | 32px |
+| | typography.base.lineHeight.t48 | 48px |
+| | typography.base.letterSpacing.default | -2% |
+
+---
+
+## Spacing
+
+### Base token
+
+여백과 간격 값을 수치 기반으로 체계화합니다.
+
+```
+spacing.base.size.s{level}
+```
+
+| Base token | Raw value |
+|------------|-----------|
+| spacing.base.size.s0 | 0px |
+| spacing.base.size.s8 | 8px |
+| spacing.base.size.s16 | 16px |
+
+**토큰 외 임의 수치(13px, 22px 등)는 사용하지 않습니다.** 디바이스 환경, 요소 간 관계, 시각적 위계를 기준으로 값을 선택합니다.
+
+- 같은 그룹 내 인접 요소 → 작은 값
+- 컴포넌트 내부 패딩 → 중간 값
+- 섹션 간 구분, 레이아웃 여백 → 큰 값
+
+Spacing은 별도의 Semantic 토큰 없이 Base 토큰을 직접 참조합니다.
+
+---
+
+## 네이밍 컨벤션 정리
+
+| 구분 | 패턴 | 예시 |
+|------|------|------|
+| Base Color | `color.base.{palette}{level}` | `color.base.orange400` |
+| Semantic Color | `color.{target}.{role}.{emphasis}.{state}` | `color.bg.brand.default` |
+| Base Typography | `typography.base.{category}.{level}` | `typography.base.size.t16` |
+| Semantic Typography | `typography.{role}{level}` | `typography.heading1` |
+| Base Spacing | `spacing.base.size.s{level}` | `spacing.base.size.s8` |


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#45-foldering-and-docs

## 🌱 PR Point

- `README.md` 작성 — 설치, 사용법, 토큰 구조, 의사결정 기록, 워크플로우 포함
- `docs/tokens.md` 추가 — 토큰 개념, Color/Typography/Spacing 구조 및 네이밍 컨벤션 상세 문서화

## 📌 참고 사항

토큰 상세 문서는 README가 길어지는 것을 방지하기 위해 `docs/tokens.md`로 분리했습니다.
README 최하단에서 링크로 연결됩니다.

## 📸 스크린샷

해당 없음

## 📮 관련 이슈
- Resolved: #45