### PR TITLE
[Feat] #54 타이포그래피 토큰 카탈로그 뷰 구현

### DIFF
--- a/MDSStoryBook/MDSStoryBook/Common/TypographyTokenItem.swift
+++ b/MDSStoryBook/MDSStoryBook/Common/TypographyTokenItem.swift
@@ -1,0 +1,18 @@
+//
+//  TypographyTokenItem.swift
+//  MDSStoryBook
+//
+//  Created by 강윤서 on 5/8/26.
+//
+
+import MDS
+
+struct TypographyTokenItem {
+    let name: String
+    let mdsFont: MDSFont
+}
+
+struct TypographyTokenSection {
+    let title: String
+    let items: [TypographyTokenItem]
+}

--- a/MDSStoryBook/MDSStoryBook/Token/TokenCategoryViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Token/TokenCategoryViewController.swift
@@ -60,6 +60,8 @@ extension TokenCategoryViewController: UITableViewDataSource, UITableViewDelegat
         switch categories[indexPath.row] {
         case "Color":
             navigationController?.pushViewController(ColorTokenViewController(), animated: true)
+        case "Typography":
+            navigationController?.pushViewController(TypographyTokenViewController(), animated: true)
         default:
             break
         }

--- a/MDSStoryBook/MDSStoryBook/Token/Typography/TypographyTokenCell.swift
+++ b/MDSStoryBook/MDSStoryBook/Token/Typography/TypographyTokenCell.swift
@@ -1,0 +1,82 @@
+//
+//  TypographyTokenCell.swift
+//  MDSStoryBook
+//
+//  Created by 강윤서 on 5/8/26.
+//
+
+import UIKit
+import MDS
+
+final class TypographyTokenCell: UITableViewCell {
+    static let reuseIdentifier = "TypographyTokenCell"
+
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 13, weight: .medium)
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let previewLabel: UILabel = {
+        let label = UILabel()
+        label.text = "다람쥐 헌 쳇바퀴에 타고파"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let propsLabel: UILabel = {
+        let label = UILabel()
+        label.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        label.textColor = .tertiaryLabel
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func setupLayout() {
+        [nameLabel, previewLabel, propsLabel].forEach { contentView.addSubview($0) }
+
+        NSLayoutConstraint.activate([
+            nameLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            nameLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            nameLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+
+            previewLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 4),
+            previewLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            previewLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+
+            propsLabel.topAnchor.constraint(equalTo: previewLabel.bottomAnchor, constant: 6),
+            propsLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            propsLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            propsLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -12),
+        ])
+    }
+
+    func configure(with item: TypographyTokenItem) {
+        nameLabel.text = item.name
+
+        let mdsFont = item.mdsFont
+        previewLabel.font = mdsFont.font
+
+        // letterSpacing을 % 로 역산
+        let letterSpacingPercent = mdsFont.font.pointSize > 0
+            ? mdsFont.letterSpacing / mdsFont.font.pointSize * 100
+            : 0
+
+        propsLabel.text = String(
+            format: "size: %.0fpx   lineHeight: %.0fpx\nletterSpacing: %.0f%%",
+            mdsFont.font.pointSize,
+            mdsFont.lineHeight,
+            letterSpacingPercent
+        )
+    }
+}

--- a/MDSStoryBook/MDSStoryBook/Token/Typography/TypographyTokenDataSource.swift
+++ b/MDSStoryBook/MDSStoryBook/Token/Typography/TypographyTokenDataSource.swift
@@ -1,0 +1,35 @@
+//
+//  TypographyTokenDataSource.swift
+//  MDSStoryBook
+//
+//  Created by 강윤서 on 5/8/26.
+//
+
+import MDS
+
+enum TypographyTokenDataSource {
+    static let sections: [TypographyTokenSection] = [
+        .init(title: "Heading", items: [
+            .init(name: "heading1", mdsFont: Typography.heading1),
+            .init(name: "heading2", mdsFont: Typography.heading2),
+            .init(name: "heading3", mdsFont: Typography.heading3),
+            .init(name: "heading4", mdsFont: Typography.heading4),
+        ]),
+        .init(title: "Title", items: [
+            .init(name: "title1", mdsFont: Typography.title1),
+            .init(name: "title2", mdsFont: Typography.title2),
+            .init(name: "title3", mdsFont: Typography.title3),
+            .init(name: "title4", mdsFont: Typography.title4),
+        ]),
+        .init(title: "Body", items: [
+            .init(name: "body1", mdsFont: Typography.body1),
+            .init(name: "body2", mdsFont: Typography.body2),
+        ]),
+        .init(title: "Label", items: [
+            .init(name: "label1", mdsFont: Typography.label1),
+            .init(name: "label2", mdsFont: Typography.label2),
+            .init(name: "label3", mdsFont: Typography.label3),
+            .init(name: "label4", mdsFont: Typography.label4),
+        ]),
+    ]
+}

--- a/MDSStoryBook/MDSStoryBook/Token/Typography/TypographyTokenViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Token/Typography/TypographyTokenViewController.swift
@@ -1,0 +1,63 @@
+//
+//  TypographyTokenViewController.swift
+//  MDSStoryBook
+//
+//  Created by 강윤서 on 5/8/26.
+//
+
+import UIKit
+
+final class TypographyTokenViewController: UIViewController {
+    private let sections = TypographyTokenDataSource.sections
+
+    private let tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .insetGrouped)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 90
+        return tableView
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Typography"
+        view.backgroundColor = .systemGroupedBackground
+        setupLayout()
+        setupTableView()
+    }
+
+    private func setupLayout() {
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    private func setupTableView() {
+        tableView.dataSource = self
+        tableView.register(TypographyTokenCell.self, forCellReuseIdentifier: TypographyTokenCell.reuseIdentifier)
+    }
+}
+
+extension TypographyTokenViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        sections[section].items.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: TypographyTokenCell.reuseIdentifier, for: indexPath) as! TypographyTokenCell
+        cell.configure(with: sections[indexPath.section].items[indexPath.row])
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        sections[section].title
+    }
+}


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#54

## 🌱 PR Point

Typography 토큰을 시각적으로 확인할 수 있는 카탈로그 화면을 구현했습니다.

**셀 구조**
```
heading1
다람쥐 헌 쳇바퀴에 타고파   ← 실제 폰트 미리보기
size: 32px   lineHeight: 48px
letterSpacing: -2%
```

**섹션 구성**
- Heading (heading1–4)
- Title (title1–4)
- Body (body1–2)
- Label (label1–4)

## 📌 참고 사항

`letterSpacing`은 `MDSFont`에 `fontSize * (percent / 100)` 으로 저장되어 있어, 역산(`letterSpacing / fontSize * 100`)하여 % 로 표시합니다.

## 📸 스크린샷
https://github.com/user-attachments/assets/49228767-fb0b-4964-a9d7-75ecd663ddaa


## 📮 관련 이슈
- Resolved: #54