### PR TITLE
[Chore] BaseSpacing 접근 제어자 internal → public 변경

### DIFF
--- a/MDS/Sources/Foundation/Base/BaseSpacing.swift
+++ b/MDS/Sources/Foundation/Base/BaseSpacing.swift
@@ -7,32 +7,32 @@
 
 import UIKit
 
-// MARK: - Base Spacing (Internal Only)
+// MARK: - Base Spacing
 
-internal enum BaseSpacing {
+public enum BaseSpacing {
 
     // MARK: Base
-    enum Base {
-        static let s0: CGFloat = 0
-        static let s2: CGFloat = 2
-        static let s4: CGFloat = 4
-        static let s6: CGFloat = 6
-        static let s8: CGFloat = 8
-        static let s10: CGFloat = 10
-        static let s12: CGFloat = 12
-        static let s14: CGFloat = 14
-        static let s16: CGFloat = 16
-        static let s20: CGFloat = 20
-        static let s24: CGFloat = 24
-        static let s28: CGFloat = 28
-        static let s32: CGFloat = 32
-        static let s36: CGFloat = 36
-        static let s40: CGFloat = 40
-        static let s48: CGFloat = 48
-        static let s64: CGFloat = 64
-        static let s72: CGFloat = 72
-        static let s80: CGFloat = 80
-        static let s120: CGFloat = 120
-        static let s160: CGFloat = 160
+    public enum Base {
+        public static let s0: CGFloat = 0
+        public static let s2: CGFloat = 2
+        public static let s4: CGFloat = 4
+        public static let s6: CGFloat = 6
+        public static let s8: CGFloat = 8
+        public static let s10: CGFloat = 10
+        public static let s12: CGFloat = 12
+        public static let s14: CGFloat = 14
+        public static let s16: CGFloat = 16
+        public static let s20: CGFloat = 20
+        public static let s24: CGFloat = 24
+        public static let s28: CGFloat = 28
+        public static let s32: CGFloat = 32
+        public static let s36: CGFloat = 36
+        public static let s40: CGFloat = 40
+        public static let s48: CGFloat = 48
+        public static let s64: CGFloat = 64
+        public static let s72: CGFloat = 72
+        public static let s80: CGFloat = 80
+        public static let s120: CGFloat = 120
+        public static let s160: CGFloat = 160
     }
 }

--- a/build.js
+++ b/build.js
@@ -88,8 +88,8 @@ StyleDictionary.registerFormat({
   name: 'ios/swift-spacing',
   format: ({ dictionary }) => {
     let output = fileHeader('BaseSpacing.swift');
-    output += '// MARK: - Base Spacing (Internal Only)\n\n';
-    output += 'internal enum BaseSpacing {\n';
+    output += '// MARK: - Base Spacing\n\n';
+    output += 'public enum BaseSpacing {\n';
 
     const groups = {};
     for (const token of dictionary.allTokens) {
@@ -100,10 +100,10 @@ StyleDictionary.registerFormat({
 
     for (const [cat, tokens] of Object.entries(groups)) {
       output += `\n    // MARK: ${capitalize(cat)}\n`;
-      output += `    enum ${capitalize(cat)} {\n`;
+      output += `    public enum ${capitalize(cat)} {\n`;
       for (const token of tokens) {
         const last = token.path[token.path.length - 1];
-        output += `        static let ${last}: CGFloat = ${toNumber(token.$value ?? token.value)}\n`;
+        output += `        public static let ${last}: CGFloat = ${toNumber(token.$value ?? token.value)}\n`;
       }
       output += `    }\n`;
     }


### PR DESCRIPTION
## Summary

Closes #57

### 변경 사항

- `build.js`: `ios/swift-spacing` 포맷의 접근 제어자를 `internal` → `public`으로 변경
- `BaseSpacing.swift`: Style Dictionary 재빌드로 자동 생성 파일 갱신

### 변경 이유

`BaseSpacing`은 외부(MDSStoryBook 등)에서 직접 사용되는 토큰이므로 `public`이어야 합니다.  
Color/Typography와 달리 Spacing은 별도의 semantic 레이어 없이 base scale이 곧 semantic 의미를 가지므로, `BaseSpacing`을 직접 공개합니다.

## Test Plan

- [ ] `npm run build` 실행 후 `BaseSpacing.swift`가 `public`으로 생성되는지 확인
- [ ] MDS 라이브러리 빌드 성공 확인
- [ ] 0.1.3 릴리즈 후 SPM으로 `BaseSpacing` 접근 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)