### PR TITLE
[Feat] #50 - Spacing 토큰 카탈로그 뷰 추가

### DIFF
--- a/MDSStoryBook/MDSStoryBook.xcodeproj/project.pbxproj
+++ b/MDSStoryBook/MDSStoryBook.xcodeproj/project.pbxproj
@@ -7,8 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3B07A7722FAE0ED800634319 /* MDS in Frameworks */ = {isa = PBXBuildFile; productRef = 3B07A7712FAE0ED800634319 /* MDS */; };
-		CB1940932F97953900451472 /* MDS in Frameworks */ = {isa = PBXBuildFile; productRef = CB1940922F97953900451472 /* MDS */; };
+		3B2CC1E02FAE22C100AFC4B7 /* MDS in Frameworks */ = {isa = PBXBuildFile; productRef = 3B2CC1DF2FAE22C100AFC4B7 /* MDS */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,8 +40,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CB1940932F97953900451472 /* MDS in Frameworks */,
-				3B07A7722FAE0ED800634319 /* MDS in Frameworks */,
+				3B2CC1E02FAE22C100AFC4B7 /* MDS in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -85,8 +83,7 @@
 			);
 			name = MDSStoryBook;
 			packageProductDependencies = (
-				CB1940922F97953900451472 /* MDS */,
-				3B07A7712FAE0ED800634319 /* MDS */,
+				3B2CC1DF2FAE22C100AFC4B7 /* MDS */,
 			);
 			productName = MDSStoryBook;
 			productReference = CB1940692F9794C300451472 /* MDSStoryBook.app */;
@@ -117,7 +114,7 @@
 			mainGroup = CB1940602F9794C300451472;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				3B07A7702FAE0ED800634319 /* XCRemoteSwiftPackageReference "SOPT-iOS-MDS" */,
+				3B2CC1DE2FAE22C100AFC4B7 /* XCRemoteSwiftPackageReference "SOPT-iOS-MDS" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CB19406A2F9794C300451472 /* Products */;
@@ -365,24 +362,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		3B07A7702FAE0ED800634319 /* XCRemoteSwiftPackageReference "SOPT-iOS-MDS" */ = {
+		3B2CC1DE2FAE22C100AFC4B7 /* XCRemoteSwiftPackageReference "SOPT-iOS-MDS" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sopt-makers/SOPT-iOS-MDS";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.2;
+				minimumVersion = 0.1.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3B07A7712FAE0ED800634319 /* MDS */ = {
+		3B2CC1DF2FAE22C100AFC4B7 /* MDS */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3B07A7702FAE0ED800634319 /* XCRemoteSwiftPackageReference "SOPT-iOS-MDS" */;
-			productName = MDS;
-		};
-		CB1940922F97953900451472 /* MDS */ = {
-			isa = XCSwiftPackageProductDependency;
+			package = 3B2CC1DE2FAE22C100AFC4B7 /* XCRemoteSwiftPackageReference "SOPT-iOS-MDS" */;
 			productName = MDS;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/MDSStoryBook/MDSStoryBook/Token/Spacing/SpacingTokenCell.swift
+++ b/MDSStoryBook/MDSStoryBook/Token/Spacing/SpacingTokenCell.swift
@@ -1,0 +1,77 @@
+//
+//  SpacingTokenCell.swift
+//  MDSStoryBook
+//
+//  Created by 강윤서 on 5/8/26.
+//
+
+import UIKit
+
+final class SpacingTokenCell: UITableViewCell {
+    static let reuseIdentifier = "SpacingTokenCell"
+
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 15, weight: .medium)
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let valueLabel: UILabel = {
+        let label = UILabel()
+        label.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
+        label.textColor = .secondaryLabel
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let barView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemBlue
+        view.layer.cornerRadius = 2
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private var barWidthConstraint: NSLayoutConstraint?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func setupLayout() {
+        [nameLabel, valueLabel, barView].forEach { contentView.addSubview($0) }
+
+        let barWidth = barView.widthAnchor.constraint(equalToConstant: 0)
+        barWidthConstraint = barWidth
+
+        NSLayoutConstraint.activate([
+            nameLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            nameLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            nameLabel.widthAnchor.constraint(equalToConstant: 40),
+
+            valueLabel.leadingAnchor.constraint(equalTo: nameLabel.trailingAnchor, constant: 8),
+            valueLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            valueLabel.widthAnchor.constraint(equalToConstant: 52),
+
+            barView.leadingAnchor.constraint(equalTo: valueLabel.trailingAnchor, constant: 12),
+            barView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            barView.heightAnchor.constraint(equalToConstant: 4),
+            barWidth,
+        ])
+    }
+
+    func configure(name: String, value: CGFloat, maxValue: CGFloat) {
+        nameLabel.text = name
+        valueLabel.text = "\(Int(value))px"
+
+        let maxBarWidth = contentView.bounds.width - 16 - 40 - 8 - 52 - 12 - 16
+        let ratio = maxValue > 0 ? value / maxValue : 0
+        barWidthConstraint?.constant = max(ratio * maxBarWidth, value == 0 ? 0 : 4)
+    }
+}

--- a/MDSStoryBook/MDSStoryBook/Token/Spacing/SpacingTokenViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Token/Spacing/SpacingTokenViewController.swift
@@ -1,0 +1,64 @@
+//
+//  SpacingTokenViewController.swift
+//  MDSStoryBook
+//
+//  Created by 강윤서 on 5/8/26.
+//
+
+import UIKit
+import MDS
+
+final class SpacingTokenViewController: UIViewController {
+    private let items: [(name: String, value: CGFloat)] = [
+        ("s0", BaseSpacing.Base.s0), ("s2", BaseSpacing.Base.s2), ("s4", BaseSpacing.Base.s4),
+        ("s6", BaseSpacing.Base.s6), ("s8", BaseSpacing.Base.s8), ("s10", BaseSpacing.Base.s10),
+        ("s12", BaseSpacing.Base.s12), ("s14", BaseSpacing.Base.s14), ("s16", BaseSpacing.Base.s16),
+        ("s20", BaseSpacing.Base.s20), ("s24", BaseSpacing.Base.s24), ("s28", BaseSpacing.Base.s28),
+        ("s32", BaseSpacing.Base.s32), ("s36", BaseSpacing.Base.s36), ("s40", BaseSpacing.Base.s40),
+        ("s48", BaseSpacing.Base.s48), ("s64", BaseSpacing.Base.s64), ("s72", BaseSpacing.Base.s72),
+        ("s80", BaseSpacing.Base.s80), ("s120", BaseSpacing.Base.s120), ("s160", BaseSpacing.Base.s160),
+    ]
+
+    private let tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .insetGrouped)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.rowHeight = 52
+        return tableView
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Spacing"
+        view.backgroundColor = .systemGroupedBackground
+        setupLayout()
+        setupTableView()
+    }
+
+    private func setupLayout() {
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    private func setupTableView() {
+        tableView.dataSource = self
+        tableView.register(SpacingTokenCell.self, forCellReuseIdentifier: SpacingTokenCell.reuseIdentifier)
+    }
+}
+
+extension SpacingTokenViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        items.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: SpacingTokenCell.reuseIdentifier, for: indexPath) as! SpacingTokenCell
+        let item = items[indexPath.row]
+        cell.configure(name: item.name, value: item.value, maxValue: BaseSpacing.Base.s160)
+        return cell
+    }
+}

--- a/MDSStoryBook/MDSStoryBook/Token/TokenCategoryViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Token/TokenCategoryViewController.swift
@@ -62,6 +62,8 @@ extension TokenCategoryViewController: UITableViewDataSource, UITableViewDelegat
             navigationController?.pushViewController(ColorTokenViewController(), animated: true)
         case "Typography":
             navigationController?.pushViewController(TypographyTokenViewController(), animated: true)
+        case "Spacing":
+            navigationController?.pushViewController(SpacingTokenViewController(), animated: true)
         default:
             break
         }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#50

## 🌱 PR Point

- `SpacingTokenViewController` 추가: `BaseSpacing.Base` 전체 토큰을 테이블 뷰로 표시
- `SpacingTokenCell` 추가: 토큰 이름, px 값, 비례 시각화 바 표시
- `TokenCategoryViewController`: Spacing 탭 시 `SpacingTokenViewController`로 이동 연결
- `project.pbxproj`: 중복 MDS 패키지 참조 제거 및 최소 버전 0.1.3 업데이트

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
https://github.com/user-attachments/assets/16685d2c-03d7-4e00-b1dd-69af1705e73b

## 📮 관련 이슈
- Resolved: #50