### PR TITLE
[Fix] #61 - BaseColorCatalogEntry, BaseTypographyCatalogEntry Sendable 준수 추가

### DIFF
--- a/MDS/Sources/Catalog/BaseColorCatalogData.swift
+++ b/MDS/Sources/Catalog/BaseColorCatalogData.swift
@@ -9,7 +9,7 @@ import UIKit
 
 // MARK: - Base Color Catalog Data
 
-@_spi(MDSCatalog) public struct BaseColorCatalogEntry {
+@_spi(MDSCatalog) public struct BaseColorCatalogEntry: @unchecked Sendable {
     public let name: String
     public let color: UIColor
 }

--- a/MDS/Sources/Catalog/BaseTypographyCatalogData.swift
+++ b/MDS/Sources/Catalog/BaseTypographyCatalogData.swift
@@ -9,7 +9,7 @@ import UIKit
 
 // MARK: - Base Typography Catalog Data
 
-@_spi(MDSCatalog) public struct BaseTypographyCatalogEntry {
+@_spi(MDSCatalog) public struct BaseTypographyCatalogEntry: Sendable {
     public let name: String
     public let value: CGFloat
 }

--- a/build.js
+++ b/build.js
@@ -209,7 +209,7 @@ StyleDictionary.registerFormat({
   format: ({ dictionary }) => {
     let output = fileHeader('BaseColorCatalogData.swift');
     output += '// MARK: - Base Color Catalog Data\n\n';
-    output += '@_spi(MDSCatalog) public struct BaseColorCatalogEntry {\n';
+    output += '@_spi(MDSCatalog) public struct BaseColorCatalogEntry: @unchecked Sendable {\n';
     output += '    public let name: String\n';
     output += '    public let color: UIColor\n';
     output += '}\n\n';
@@ -246,7 +246,7 @@ StyleDictionary.registerFormat({
   format: ({ dictionary }) => {
     let output = fileHeader('BaseTypographyCatalogData.swift');
     output += '// MARK: - Base Typography Catalog Data\n\n';
-    output += '@_spi(MDSCatalog) public struct BaseTypographyCatalogEntry {\n';
+    output += '@_spi(MDSCatalog) public struct BaseTypographyCatalogEntry: Sendable {\n';
     output += '    public let name: String\n';
     output += '    public let value: CGFloat\n';
     output += '}\n\n';


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/#61-catalog-entry-sendable

## 🌱 PR Point
- `BaseColorCatalogEntry`: `UIColor`가 Swift 6에서 `Sendable` 미준수로 인한 에러 해결 → `@unchecked Sendable` 적용
- `BaseTypographyCatalogEntry`: `String`, `CGFloat` 모두 `Sendable`이므로 `Sendable` 직접 적용
- `build.js` 포맷 수정 및 파일 재생성

## 📌 참고 사항
- `UIColor`는 Objective-C 클래스라 `Sendable`을 직접 준수하지 않음
- 카탈로그 데이터는 생성 후 변경되지 않으므로 `@unchecked Sendable` 적용이 안전함

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|해당 없음||

## 📮 관련 이슈
- Resolved: #61