### PR TITLE
[Feat] #68 - MDSChip 컴포넌트 구현

### DIFF
--- a/MDS/Sources/Components/MDSChip.swift
+++ b/MDS/Sources/Components/MDSChip.swift
@@ -1,0 +1,72 @@
+//
+//  MDSChip.swift
+//  MDS
+//
+
+import UIKit
+
+public final class MDSChip: UIButton {
+
+    // MARK: - Properties
+
+    public var chipTitle: String? {
+        didSet { setNeedsUpdateConfiguration() }
+    }
+
+    private let chipSize: Size
+
+    // MARK: - Init
+
+    public init(size: Size = .medium) {
+        self.chipSize = size
+        super.init(frame: .zero)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - Setup
+
+    private func setup() {
+        var config = UIButton.Configuration.plain()
+        config.contentInsets = chipSize.contentInsets
+        config.cornerStyle = .capsule
+        configuration = config
+
+        configurationUpdateHandler = { [weak self] button in
+            guard let self, var config = button.configuration else { return }
+            self.applyAppearance(to: &config, isSelected: button.isSelected)
+            button.configuration = config
+        }
+    }
+
+    // MARK: - Appearance
+
+    private func applyAppearance(to config: inout UIButton.Configuration, isSelected: Bool) {
+        config.background.backgroundColor = isSelected
+            ? SemanticColor.Bg.Neutral.subtle
+            : SemanticColor.Bg.Neutral.ghost
+
+        config.background.strokeColor = isSelected
+            ? SemanticColor.Stroke.Neutral.inverse
+            : SemanticColor.Stroke.Neutral.subtle
+        config.background.strokeWidth = 1
+
+        let textColor = isSelected
+            ? SemanticColor.Fg.Neutral.bold
+            : SemanticColor.Fg.Neutral.subtle
+
+        let typography = chipSize.typography
+        config.attributedTitle = AttributedString(
+            NSAttributedString(
+                string: chipTitle ?? "",
+                attributes: [
+                    .font: typography.font,
+                    .kern: typography.letterSpacing,
+                    .foregroundColor: textColor
+                ]
+            )
+        )
+    }
+}

--- a/MDS/Sources/Components/MDSChipType.swift
+++ b/MDS/Sources/Components/MDSChipType.swift
@@ -1,0 +1,28 @@
+//
+//  MDSChipType.swift
+//  MDS
+//
+
+import UIKit
+
+extension MDSChip {
+
+    public enum Size {
+        case small
+        case medium
+
+        var contentInsets: NSDirectionalEdgeInsets {
+            switch self {
+            case .small:  return NSDirectionalEdgeInsets(top: 9, leading: 14, bottom: 9, trailing: 14)
+            case .medium: return NSDirectionalEdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20)
+            }
+        }
+
+        var typography: MDSFont {
+            switch self {
+            case .small:  return Typography.label3
+            case .medium: return Typography.label2
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#68
- 
## 🌱 PR Point
- `MDSChip.Size` enum 정의 (`MDSChipType.swift` 별도 파일 분리)
  - `small` (height 36px, padding 9/14px, `Typography.label3`)
  - `medium` (height 42px, padding 10/20px, `Typography.label2`)

- `MDSChip: UIButton` 구현
  - `UIButton.Configuration` 기반 pill shape 버튼
  - `configurationUpdateHandler`를 통해 `isSelected` 상태 변화 시 외형 자동 갱신
  - Default / Selected 두 가지 상태에 따른 배경색, 테두리, 텍스트 색상 처리

## 📌 참고 사항
- Hover 상태는 iOS 모바일 환경에서 해당 없어 구현하지 않음

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|Chip| <img width="375" alt="image" src="https://github.com/user-attachments/assets/7a5aa8df-deaa-4663-8d78-7b52b2cd42e2" /> |

## 📮 관련 이슈
- Resolved: #68