### PR TITLE
[Feat] #71 - MDSChip 카탈로그 앱 추가

### DIFF
--- a/MDSStoryBook/MDSStoryBook.xcodeproj/project.pbxproj
+++ b/MDSStoryBook/MDSStoryBook.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3B4B68342FB9B9670042AAA5 /* MDS in Frameworks */ = {isa = PBXBuildFile; productRef = 3B4B68332FB9B9670042AAA5 /* MDS */; };
+		3B50BC0D2FBB197000972B89 /* MDS in Frameworks */ = {isa = PBXBuildFile; productRef = 3B50BC0C2FBB197000972B89 /* MDS */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,7 +40,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3B4B68342FB9B9670042AAA5 /* MDS in Frameworks */,
+				3B50BC0D2FBB197000972B89 /* MDS in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -83,7 +83,7 @@
 			);
 			name = MDSStoryBook;
 			packageProductDependencies = (
-				3B4B68332FB9B9670042AAA5 /* MDS */,
+				3B50BC0C2FBB197000972B89 /* MDS */,
 			);
 			productName = MDSStoryBook;
 			productReference = CB1940692F9794C300451472 /* MDSStoryBook.app */;
@@ -114,7 +114,7 @@
 			mainGroup = CB1940602F9794C300451472;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				3B4B68322FB9B9670042AAA5 /* XCRemoteSwiftPackageReference "SOPT-iOS-MDS" */,
+				3B50BC0B2FBB197000972B89 /* XCLocalSwiftPackageReference "../../SOPT-iOS-MDS" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CB19406A2F9794C300451472 /* Products */;
@@ -361,21 +361,16 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		3B4B68322FB9B9670042AAA5 /* XCRemoteSwiftPackageReference "SOPT-iOS-MDS" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/sopt-makers/SOPT-iOS-MDS";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.4;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		3B50BC0B2FBB197000972B89 /* XCLocalSwiftPackageReference "../../SOPT-iOS-MDS" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../../SOPT-iOS-MDS";
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3B4B68332FB9B9670042AAA5 /* MDS */ = {
+		3B50BC0C2FBB197000972B89 /* MDS */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3B4B68322FB9B9670042AAA5 /* XCRemoteSwiftPackageReference "SOPT-iOS-MDS" */;
 			productName = MDS;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/MDSStoryBook/MDSStoryBook.xcodeproj/project.pbxproj
+++ b/MDSStoryBook/MDSStoryBook.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3B50BC0D2FBB197000972B89 /* MDS in Frameworks */ = {isa = PBXBuildFile; productRef = 3B50BC0C2FBB197000972B89 /* MDS */; };
+		3B5857642FBC3BFB00AE72A8 /* MDS in Frameworks */ = {isa = PBXBuildFile; productRef = 3B5857632FBC3BFB00AE72A8 /* MDS */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,7 +40,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3B50BC0D2FBB197000972B89 /* MDS in Frameworks */,
+				3B5857642FBC3BFB00AE72A8 /* MDS in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -83,7 +83,7 @@
 			);
 			name = MDSStoryBook;
 			packageProductDependencies = (
-				3B50BC0C2FBB197000972B89 /* MDS */,
+				3B5857632FBC3BFB00AE72A8 /* MDS */,
 			);
 			productName = MDSStoryBook;
 			productReference = CB1940692F9794C300451472 /* MDSStoryBook.app */;
@@ -114,7 +114,7 @@
 			mainGroup = CB1940602F9794C300451472;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				3B50BC0B2FBB197000972B89 /* XCLocalSwiftPackageReference "../../SOPT-iOS-MDS" */,
+				3B5857622FBC3BFB00AE72A8 /* XCRemoteSwiftPackageReference "SOPT-iOS-MDS" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CB19406A2F9794C300451472 /* Products */;
@@ -361,16 +361,21 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		3B50BC0B2FBB197000972B89 /* XCLocalSwiftPackageReference "../../SOPT-iOS-MDS" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = "../../SOPT-iOS-MDS";
+/* Begin XCRemoteSwiftPackageReference section */
+		3B5857622FBC3BFB00AE72A8 /* XCRemoteSwiftPackageReference "SOPT-iOS-MDS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sopt-makers/SOPT-iOS-MDS";
+			requirement = {
+				branch = default;
+				kind = branch;
+			};
 		};
-/* End XCLocalSwiftPackageReference section */
+/* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3B50BC0C2FBB197000972B89 /* MDS */ = {
+		3B5857632FBC3BFB00AE72A8 /* MDS */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 3B5857622FBC3BFB00AE72A8 /* XCRemoteSwiftPackageReference "SOPT-iOS-MDS" */;
 			productName = MDS;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/MDSStoryBook/MDSStoryBook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MDSStoryBook/MDSStoryBook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sopt-makers/SOPT-iOS-MDS",
       "state" : {
-        "revision" : "46ffe8cc4448819fe6b09b62af378a9d7bb9683a",
-        "version" : "0.1.4"
+        "branch" : "default",
+        "revision" : "f076e94f59bbd799d5483d84715355ab8a705caa"
       }
     }
   ],

--- a/MDSStoryBook/MDSStoryBook/Component/Chip/ChipViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/Chip/ChipViewController.swift
@@ -1,0 +1,131 @@
+//
+//  ChipViewController.swift
+//  MDSStoryBook
+//
+
+import UIKit
+import MDS
+
+final class ChipViewController: UIViewController {
+
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+
+    private let contentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 32
+        stack.layoutMargins = UIEdgeInsets(top: 24, left: 20, bottom: 24, right: 20)
+        stack.isLayoutMarginsRelativeArrangement = true
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Chip"
+        view.backgroundColor = .systemGroupedBackground
+        setupLayout()
+        setupChips()
+    }
+
+    private func setupLayout() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+        ])
+    }
+
+    private func setupChips() {
+        let sections: [(title: String, size: MDSChip.Size)] = [
+            ("Small", .small),
+            ("Medium", .medium),
+        ]
+
+        sections.forEach { section in
+            contentStack.addArrangedSubview(makeSection(title: section.title, size: section.size))
+        }
+    }
+
+    private func makeSection(title: String, size: MDSChip.Size) -> UIView {
+        let sectionTitle = UILabel()
+        sectionTitle.text = title
+        sectionTitle.font = .systemFont(ofSize: 13, weight: .semibold)
+        sectionTitle.textColor = .secondaryLabel
+
+        let card = UIView()
+        card.backgroundColor = SemanticColor.Bg.Dim.default
+        card.layer.cornerRadius = 12
+
+        let cardStack = UIStackView()
+        cardStack.axis = .horizontal
+        cardStack.distribution = .fillEqually
+        cardStack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(cardStack)
+
+        NSLayoutConstraint.activate([
+            cardStack.topAnchor.constraint(equalTo: card.topAnchor, constant: 20),
+            cardStack.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -20),
+            cardStack.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 16),
+            cardStack.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -16),
+        ])
+
+        cardStack.addArrangedSubview(makeChipItem(size: size, isInteractive: true))
+        cardStack.addArrangedSubview(makeChipItem(size: size, isInteractive: false))
+
+        let sectionStack = UIStackView()
+        sectionStack.axis = .vertical
+        sectionStack.spacing = 8
+        sectionStack.addArrangedSubview(sectionTitle)
+        sectionStack.addArrangedSubview(card)
+        return sectionStack
+    }
+
+    private func makeChipItem(size: MDSChip.Size, isInteractive: Bool) -> UIView {
+        let itemStack = UIStackView()
+        itemStack.axis = .vertical
+        itemStack.spacing = 12
+        itemStack.alignment = .center
+
+        let descriptionLabel = UILabel()
+        descriptionLabel.font = .systemFont(ofSize: 11)
+        descriptionLabel.textColor = SemanticColor.Fg.Neutral.subtle
+        descriptionLabel.numberOfLines = 0
+        descriptionLabel.textAlignment = .center
+
+        let chip = MDSChip(size: size)
+
+        if isInteractive {
+            chip.chipTitle = "Chip"
+            descriptionLabel.text = "탭하여 선택 상태 변경"
+            chip.addTarget(self, action: #selector(chipTapped(_:)), for: .touchUpInside)
+        } else {
+            chip.chipTitle = "Chip"
+            chip.isSelected = true
+            chip.isUserInteractionEnabled = false
+            descriptionLabel.text = "항상 Selected 상태"
+        }
+
+        itemStack.addArrangedSubview(chip)
+        itemStack.addArrangedSubview(descriptionLabel)
+        return itemStack
+    }
+
+    @objc private func chipTapped(_ sender: MDSChip) {
+        sender.isSelected.toggle()
+    }
+}

--- a/MDSStoryBook/MDSStoryBook/Component/ComponentCategoryViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/ComponentCategoryViewController.swift
@@ -1,14 +1,12 @@
 //
-//  HomeViewController.swift
+//  ComponentCategoryViewController.swift
 //  MDSStoryBook
-//
-//  Created by 강윤서 on 5/8/26.
 //
 
 import UIKit
 
-final class HomeViewController: UIViewController {
-    private let items = ["Token", "Component"]
+final class ComponentCategoryViewController: UIViewController {
+    private let categories = ["Chip", "Tag"]
 
     private let tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .insetGrouped)
@@ -19,7 +17,7 @@ final class HomeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "MDS Catalog"
+        title = "Component"
         view.backgroundColor = .systemGroupedBackground
         setupLayout()
         setupTableView()
@@ -38,30 +36,28 @@ final class HomeViewController: UIViewController {
     private func setupTableView() {
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "HomeCell")
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "CategoryCell")
     }
 }
 
-extension HomeViewController: UITableViewDataSource, UITableViewDelegate {
+extension ComponentCategoryViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        items.count
+        categories.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        var cell = tableView.dequeueReusableCell(withIdentifier: "HomeCell", for: indexPath)
-        cell = UITableViewCell(style: .default, reuseIdentifier: "HomeCell")
-        cell.textLabel?.text = items[indexPath.row]
+        var cell = tableView.dequeueReusableCell(withIdentifier: "CategoryCell", for: indexPath)
+        cell = UITableViewCell(style: .default, reuseIdentifier: "CategoryCell")
+        cell.textLabel?.text = categories[indexPath.row]
         cell.accessoryType = .disclosureIndicator
         return cell
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        switch items[indexPath.row] {
-        case "Token":
-            navigationController?.pushViewController(TokenCategoryViewController(), animated: true)
-        case "Component":
-            navigationController?.pushViewController(ComponentCategoryViewController(), animated: true)
+        switch categories[indexPath.row] {
+        case "Chip":
+            navigationController?.pushViewController(ChipViewController(), animated: true)
         default:
             break
         }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#71

## 🌱 PR Point
### `ComponentCategoryViewController` 추가
- Small / Medium 섹션별 다크 배경 카드 구성
- 좌측: 탭하여 Default ↔ Selected 상태 토글 가능한 인터랙티브 칩
- 우측: 항상 Selected 상태로 고정된 칩
- 각 칩 하단 설명 레이블 표시

## 💡 사용 방법

### 기본 초기화

```swift
// size 기본값은 .medium
let chip = MDSChip()

// size를 명시적으로 지정
let smallChip = MDSChip(size: .small)
let mediumChip = MDSChip(size: .medium)
```

### 텍스트 설정

```swift
chip.chipTitle = "Chip"
```

### 선택 상태 제어

```swift
// 선택 상태로 설정
chip.isSelected = true

// 탭으로 상태 토글
chip.addTarget(self, action: #selector(chipTapped(_:)), for: .touchUpInside)

@objc private func chipTapped(_ sender: MDSChip) {
    sender.isSelected.toggle()
}
```

### 인터랙션 비활성화 (항상 Selected 고정)

```swift
chip.isSelected = true
chip.isUserInteractionEnabled = false
```

### Size별 스펙

| Size | Typography | Padding (vertical) | Padding (horizontal) |
|:----:|:----------:|:------------------:|:--------------------:|
| `.small` | `label3` | 9pt | 14pt |
| `.medium` | `label2` | 10pt | 20pt |

## 📌 참고 사항
- feat/#68 머지 이후 머지 필요
- border 색상 확인을 위해 배경 색을 어둡게 설정

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|Chip 카탈로그|<img width="375" alt="image" src="https://github.com/user-attachments/assets/d3666c05-8882-484a-bcd8-912893c39d79" />|

## 📮 관련 이슈
- Resolved: #71