### PR TITLE
[Feat] #74 - MDSTag 카탈로그 앱 추가

### DIFF
--- a/MDSStoryBook/MDSStoryBook/Component/ComponentCategoryViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/ComponentCategoryViewController.swift
@@ -1,14 +1,12 @@
 //
-//  HomeViewController.swift
+//  ComponentCategoryViewController.swift
 //  MDSStoryBook
-//
-//  Created by 강윤서 on 5/8/26.
 //
 
 import UIKit
 
-final class HomeViewController: UIViewController {
-    private let items = ["Token", "Component"]
+final class ComponentCategoryViewController: UIViewController {
+    private let categories = ["Tag"]
 
     private let tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .insetGrouped)
@@ -19,7 +17,7 @@ final class HomeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "MDS Catalog"
+        title = "Component"
         view.backgroundColor = .systemGroupedBackground
         setupLayout()
         setupTableView()
@@ -38,30 +36,28 @@ final class HomeViewController: UIViewController {
     private func setupTableView() {
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "HomeCell")
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "CategoryCell")
     }
 }
 
-extension HomeViewController: UITableViewDataSource, UITableViewDelegate {
+extension ComponentCategoryViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        items.count
+        categories.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        var cell = tableView.dequeueReusableCell(withIdentifier: "HomeCell", for: indexPath)
-        cell = UITableViewCell(style: .default, reuseIdentifier: "HomeCell")
-        cell.textLabel?.text = items[indexPath.row]
+        var cell = tableView.dequeueReusableCell(withIdentifier: "CategoryCell", for: indexPath)
+        cell = UITableViewCell(style: .default, reuseIdentifier: "CategoryCell")
+        cell.textLabel?.text = categories[indexPath.row]
         cell.accessoryType = .disclosureIndicator
         return cell
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        switch items[indexPath.row] {
-        case "Token":
-            navigationController?.pushViewController(TokenCategoryViewController(), animated: true)
-        case "Component":
-            navigationController?.pushViewController(ComponentCategoryViewController(), animated: true)
+        switch categories[indexPath.row] {
+        case "Tag":
+            navigationController?.pushViewController(TagViewController(), animated: true)
         default:
             break
         }

--- a/MDSStoryBook/MDSStoryBook/Component/Tag/TagViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/Tag/TagViewController.swift
@@ -1,0 +1,176 @@
+//
+//  TagViewController.swift
+//  MDSStoryBook
+//
+
+import UIKit
+import MDS
+
+final class TagViewController: UIViewController {
+
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+
+    private let contentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 32
+        stack.layoutMargins = UIEdgeInsets(top: 24, left: 20, bottom: 24, right: 20)
+        stack.isLayoutMarginsRelativeArrangement = true
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Tag"
+        view.backgroundColor = .systemGroupedBackground
+        setupLayout()
+        setupTags()
+    }
+
+    private func setupLayout() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+        ])
+    }
+
+    private func setupTags() {
+        let sizes: [(title: String, size: MDSTag.Size)] = [
+            ("Small (h=22)", .small),
+            ("Medium (h=24)", .medium),
+            ("Large (h=28)", .large),
+        ]
+
+        sizes.forEach { item in
+            contentStack.addArrangedSubview(makeSizeSection(title: item.title, size: item.size))
+        }
+    }
+
+    private func makeSizeSection(title: String, size: MDSTag.Size) -> UIView {
+        let titleLabel = UILabel()
+        titleLabel.text = title
+        titleLabel.font = .systemFont(ofSize: 20, weight: .bold)
+        titleLabel.textColor = .label
+
+        let sectionStack = UIStackView()
+        sectionStack.axis = .vertical
+        sectionStack.spacing = 8
+        sectionStack.addArrangedSubview(titleLabel)
+
+        let combinations: [(variant: MDSTag.Variant, style: MDSTag.Style, name: String)] = [
+            (.default, .solid, "Default / Solid"),
+            (.default, .subtle, "Default / Subtle"),
+            (.primary, .solid, "Primary / Solid"),
+            (.primary, .subtle, "Primary / Subtle"),
+            (.secondary, .solid, "Secondary / Solid"),
+            (.secondary, .subtle, "Secondary / Subtle"),
+        ]
+
+        combinations.forEach { combo in
+            sectionStack.addArrangedSubview(
+                makeVariantRow(
+                    label: combo.name,
+                    size: size,
+                    variant: combo.variant,
+                    style: combo.style
+                )
+            )
+        }
+
+        return sectionStack
+    }
+
+    private func makeVariantRow(
+        label: String,
+        size: MDSTag.Size,
+        variant: MDSTag.Variant,
+        style: MDSTag.Style
+    ) -> UIView {
+        let rowLabel = UILabel()
+        rowLabel.text = label
+        rowLabel.font = .systemFont(ofSize: 12, weight: .semibold)
+        rowLabel.textColor = .secondaryLabel
+
+        let card = UIView()
+        card.backgroundColor = SemanticColor.Bg.Dim.default
+        card.layer.cornerRadius = 12
+
+        let tagRow = UIStackView()
+        tagRow.axis = .horizontal
+        tagRow.spacing = 16
+        tagRow.alignment = .center
+        tagRow.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        tagRow.isLayoutMarginsRelativeArrangement = true
+        tagRow.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(tagRow)
+
+        NSLayoutConstraint.activate([
+            tagRow.topAnchor.constraint(equalTo: card.topAnchor),
+            tagRow.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+            tagRow.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            tagRow.trailingAnchor.constraint(lessThanOrEqualTo: card.trailingAnchor),
+        ])
+
+        let icon = UIImage(systemName: "star.fill")
+        let shapes: [(MDSTag.Shape, String)] = [(.rect, "Rect"), (.pill, "Pill")]
+        shapes.forEach { shape, shapeName in
+            tagRow.addArrangedSubview(makeTagItem(
+                size: size, shape: shape, variant: variant, style: style,
+                icon: nil, description: shapeName
+            ))
+            tagRow.addArrangedSubview(makeTagItem(
+                size: size, shape: shape, variant: variant, style: style,
+                icon: icon, description: "\(shapeName)+Icon"
+            ))
+        }
+
+        let rowStack = UIStackView()
+        rowStack.axis = .vertical
+        rowStack.spacing = 6
+        rowStack.addArrangedSubview(rowLabel)
+        rowStack.addArrangedSubview(card)
+        return rowStack
+    }
+
+    private func makeTagItem(
+        size: MDSTag.Size,
+        shape: MDSTag.Shape,
+        variant: MDSTag.Variant,
+        style: MDSTag.Style,
+        icon: UIImage?,
+        description: String
+    ) -> UIView {
+        let itemStack = UIStackView()
+        itemStack.axis = .vertical
+        itemStack.spacing = 6
+        itemStack.alignment = .center
+
+        let tag = MDSTag(text: "Tag", size: size, shape: shape, variant: variant, style: style, icon: icon)
+
+        let descLabel = UILabel()
+        descLabel.text = description
+        descLabel.font = .systemFont(ofSize: 9)
+        descLabel.textColor = SemanticColor.Fg.Neutral.subtle
+        descLabel.textAlignment = .center
+
+        itemStack.addArrangedSubview(tag)
+        itemStack.addArrangedSubview(descLabel)
+        return itemStack
+    }
+}


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#74-tag-catalog

## 🌱 PR Point

### 구조 설계
`feat/#69-tag` 브랜치(MDSTag 컴포넌트)를 base로 분기하여, MDSTag가 실제 앱에서 어떻게 보이는지 배포 전에 카탈로그 앱에서 확인할 수 있도록 구성했습니다.

**추가된 파일**
- `HomeViewController` — Component 탭 추가 및 `ComponentCategoryViewController` 연결
- `ComponentCategoryViewController` — Component 카테고리 목록 (현재 Tag)
- `TagViewController` — MDSTag 72가지 조합 뷰

### TagViewController 구성
UIScrollView + UIStackView 구조로 구현했습니다. UITableView의 셀 재사용은 수백 개 이상의 동적 리스트에 유효하지만, 이 화면은 72개 고정 뷰이므로 더 단순한 스크롤 뷰 방식을 선택했습니다.

**계층 구조**
```
Size 섹션 (Small / Medium / Large)
  └── Variant × Style 행 (Default·Solid / Default·Subtle / Primary·Solid / Primary·Subtle / Secondary·Solid / Secondary·Subtle)
        └── Shape × Icon 조합 (Rect / Rect+Icon / Pill / Pill+Icon)
```
3 size × 6 (variant·style) × 4 (shape·icon) = **72가지**

### 프로젝트에서의 사용 방법
```swift
// 텍스트만
let tag = MDSTag(text: "태그", size: .medium, shape: .pill, variant: .primary, style: .solid)

// 아이콘 포함
let tag = MDSTag(text: "태그", size: .medium, shape: .pill, variant: .primary, style: .solid, icon: MDSIcon.star.image)
```

## 📌 참고 사항
- 이 PR은 `feat/#69-tag`를 base로 합니다. MDSTag PR이 먼저 머지된 후 `default`로 머지해주세요.

## 📸 스크린샷
https://github.com/user-attachments/assets/ac8146b2-8a87-4ccf-8171-5540b6ea4085



## 📮 관련 이슈
- Resolved: #74