### PR TITLE
[Feat] #90 - MDSActionButton 컴포넌트 구현

### DIFF
--- a/MDS/Sources/Components/ActionButton/MDSActionButton.swift
+++ b/MDS/Sources/Components/ActionButton/MDSActionButton.swift
@@ -1,0 +1,223 @@
+//
+//  MDSActionButton.swift
+//  MDS
+//
+//  Created by yungu0010 on 5/25/26.
+//
+
+import UIKit
+
+public final class MDSActionButton: UIControl {
+
+    // MARK: - Properties
+
+    public var title: String? {
+        didSet { updateAppearance() }
+    }
+
+    public var prefixIcon: UIImage? {
+        didSet {
+            prefixImageView.image = prefixIcon?.withRenderingMode(.alwaysTemplate)
+            prefixImageView.isHidden = prefixIcon == nil
+        }
+    }
+
+    public var suffixIcon: UIImage? {
+        didSet {
+            suffixImageView.image = suffixIcon?.withRenderingMode(.alwaysTemplate)
+            suffixImageView.isHidden = suffixIcon == nil
+        }
+    }
+
+    public override var isHighlighted: Bool {
+        didSet { updateAppearance() }
+    }
+
+    public override var isEnabled: Bool {
+        didSet { updateAppearance() }
+    }
+
+    private let variant: Variant
+    private let size: Size
+
+    // MARK: - Subviews
+
+    private let contentStackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .horizontal
+        view.alignment = .center
+        view.isUserInteractionEnabled = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let prefixImageView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFit
+        view.isHidden = true
+        return view
+    }()
+
+    private let titleLabel: UILabel = {
+        let view = UILabel()
+        view.textAlignment = .center
+        view.numberOfLines = 1
+        return view
+    }()
+
+    private let suffixImageView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFit
+        view.isHidden = true
+        return view
+    }()
+
+    // MARK: - Init
+
+    public init(variant: Variant = .primary, size: Size = .large) {
+        self.variant = variant
+        self.size = size
+        super.init(frame: .zero)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - Setup
+
+    private func setup() {
+        let sizeToken = SizeToken(size: size)
+
+        layer.cornerRadius = sizeToken.cornerRadius
+        layer.masksToBounds = true
+
+        contentStackView.spacing = sizeToken.iconGap
+        contentStackView.addArrangedSubview(prefixImageView)
+        contentStackView.addArrangedSubview(titleLabel)
+        contentStackView.addArrangedSubview(suffixImageView)
+        addSubview(contentStackView)
+
+        let insets = sizeToken.contentInsets
+        let iconSize = sizeToken.iconSize
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: sizeToken.height),
+
+            contentStackView.topAnchor.constraint(equalTo: topAnchor, constant: insets.top),
+            contentStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -insets.bottom),
+            contentStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: insets.leading),
+            contentStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -insets.trailing),
+
+            prefixImageView.widthAnchor.constraint(equalToConstant: iconSize),
+            prefixImageView.heightAnchor.constraint(equalToConstant: iconSize),
+            suffixImageView.widthAnchor.constraint(equalToConstant: iconSize),
+            suffixImageView.heightAnchor.constraint(equalToConstant: iconSize),
+        ])
+
+        updateAppearance()
+    }
+
+    // MARK: - Appearance
+
+    private func updateAppearance() {
+        let colorToken = ColorToken(variant: variant, isHighlighted: isHighlighted, isEnabled: isEnabled)
+        let sizeToken = SizeToken(size: size)
+
+        backgroundColor = colorToken.background
+
+        titleLabel.attributedText = NSAttributedString(
+            string: title ?? "",
+            attributes: [
+                .font: sizeToken.typography.font,
+                .kern: sizeToken.typography.letterSpacing,
+                .foregroundColor: colorToken.foreground
+            ]
+        )
+
+        prefixImageView.tintColor = colorToken.foreground
+        suffixImageView.tintColor = colorToken.foreground
+    }
+}
+
+// MARK: - Size Token
+
+private extension MDSActionButton {
+
+    struct SizeToken {
+        let height: CGFloat
+        let cornerRadius: CGFloat
+        let contentInsets: NSDirectionalEdgeInsets
+        let iconGap: CGFloat
+        let iconSize: CGFloat
+        let typography: MDSFont
+
+        init(size: MDSActionButton.Size) {
+            switch size {
+            case .xsmall:
+                height = 32
+                cornerRadius = BaseRadius.Base.r16
+                contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12)
+                iconGap = 2
+                iconSize = 16
+                typography = Typography.label4
+            case .small:
+                height = 36
+                cornerRadius = BaseRadius.Base.r8
+                contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 14, bottom: 10, trailing: 14)
+                iconGap = 4
+                iconSize = 16
+                typography = Typography.label3
+            case .medium:
+                height = 46
+                cornerRadius = BaseRadius.Base.r10
+                contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 20, bottom: 12, trailing: 20)
+                iconGap = 4
+                iconSize = 20
+                typography = Typography.label2
+            case .large:
+                height = 56
+                cornerRadius = BaseRadius.Base.r12
+                contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 24, bottom: 16, trailing: 24)
+                iconGap = 4
+                iconSize = 24
+                typography = Typography.label1
+            }
+        }
+    }
+}
+
+// MARK: - Color Token
+
+private extension MDSActionButton {
+
+    struct ColorToken {
+        let background: UIColor
+        let foreground: UIColor
+
+        init(variant: MDSActionButton.Variant, isHighlighted: Bool, isEnabled: Bool) {
+            guard isEnabled else {
+                background = SemanticColor.Bg.Neutral.Default.disabled
+                foreground = SemanticColor.Fg.Neutral.Default.disabled
+                return
+            }
+            switch variant {
+            case .primary:
+                background = isHighlighted
+                    ? SemanticColor.Bg.Neutral.Inverse.hover
+                    : SemanticColor.Bg.Neutral.inverse
+                foreground = SemanticColor.Fg.Neutral.inverse
+            case .secondary:
+                background = isHighlighted
+                    ? SemanticColor.Bg.Neutral.Subtle.hover
+                    : SemanticColor.Bg.Neutral.subtle
+                foreground = SemanticColor.Fg.Neutral.bold
+            case .danger:
+                background = isHighlighted
+                    ? SemanticColor.Bg.Danger.Default.pressed
+                    : SemanticColor.Bg.Danger.default
+                foreground = SemanticColor.Fg.Neutral.bold
+            }
+        }
+    }
+}

--- a/MDS/Sources/Components/ActionButton/MDSActionButton.swift
+++ b/MDS/Sources/Components/ActionButton/MDSActionButton.swift
@@ -76,7 +76,12 @@ public final class MDSActionButton: UIControl {
 
     public init(variant: Variant = .primary, size: Size = .large) {
         self.variant = variant
-        self.size = size
+        if variant == .danger && size == .xsmall {
+            assertionFailure("MDSActionButton: danger variant은 xsmall size를 지원하지 않습니다.")
+            self.size = .small
+        } else {
+            self.size = size
+        }
         super.init(frame: .zero)
         setup()
     }

--- a/MDS/Sources/Components/ActionButton/MDSActionButton.swift
+++ b/MDS/Sources/Components/ActionButton/MDSActionButton.swift
@@ -92,8 +92,13 @@ public final class MDSActionButton: UIControl {
     // MARK: - Setup
 
     private func setup() {
-        let sizeToken = SizeToken(size: size)
+        setupHierarchy()
+        setupLayout()
+        updateAppearance()
+    }
 
+    private func setupHierarchy() {
+        let sizeToken = SizeToken(size: size)
         layer.cornerRadius = sizeToken.cornerRadius
         layer.masksToBounds = true
 
@@ -102,7 +107,10 @@ public final class MDSActionButton: UIControl {
         contentStackView.addArrangedSubview(titleLabel)
         contentStackView.addArrangedSubview(suffixImageView)
         addSubview(contentStackView)
+    }
 
+    private func setupLayout() {
+        let sizeToken = SizeToken(size: size)
         let insets = sizeToken.contentInsets
         let iconSize = sizeToken.iconSize
 
@@ -119,8 +127,6 @@ public final class MDSActionButton: UIControl {
             suffixImageView.widthAnchor.constraint(equalToConstant: iconSize),
             suffixImageView.heightAnchor.constraint(equalToConstant: iconSize),
         ])
-
-        updateAppearance()
     }
 
     // MARK: - Appearance

--- a/MDS/Sources/Components/ActionButton/MDSActionButtonType.swift
+++ b/MDS/Sources/Components/ActionButton/MDSActionButtonType.swift
@@ -1,0 +1,22 @@
+//
+//  MDSActionButtonType.swift
+//  MDS
+//
+//  Created by yungu0010 on 5/25/26.
+//
+
+public extension MDSActionButton {
+
+    enum Variant {
+        case primary
+        case secondary
+        case danger
+    }
+
+    enum Size {
+        case xsmall
+        case small
+        case medium
+        case large
+    }
+}


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#90

## 🌱 PR Point

### UIControl + UIStackView 선택 이유
**prefix/suffix 아이콘이 각각 독립적으로 optional**이기 때문에 `UIButton` 대신 `UIControl + UIStackView`를 사용했습니다.
- `UIButton.Configuration`은 `image` 프로퍼티가 하나뿐이라 prefix/suffix를 동시에 표현할 수 없음
- `UIControl + UIStackView`는 `prefixImageView`, `titleLabel`, `suffixImageView`를 각각 arranged subview로 구성하여, `isHidden = true` 처리만으로 UIStackView가 해당 뷰를 자동으로 collapse함.
- 별도의 `layoutSubviews` 오버라이드 없이 4가지 조합(없음 / prefix만 / suffix만 / 둘 다)을 모두 처리할 수 있음.
- 탭 이벤트는 `UIControl`의 `addTarget(_:action:for:)` 으로 동일하게 지원.

### didSet 프로퍼티를 사용한 이유

`title`, `prefixIcon`, `suffixIcon`을 `init` 파라미터 대신 프로퍼티로 둔 이유는 **초기화 이후에도 외부에서 값을 변경할 수 있도록** 하기 위해서입니다.
- `init`에 넣으면 값을 바꿀 때마다 버튼을 새로 생성
- `didSet`을 통해 값이 바뀌는 시점에 UI가 즉시 반영
- `variant`와 `size`는 레이아웃을 결정하므로 변경을 허용하지 않고 `init`에서만 받음

### danger + xsmall 스펙 불일치 처리

danger variant는 디자인 스펙상 xsmall size를 지원하지 않습니다. 런타임에서 허용 상태를 방지하기 위해 `init`에서 아래와 같이 처리합니다.
- **Debug**: `assertionFailure`로 스펙 위반을 즉시 감지
- **Release**: `.small`로 폴백하여 앱이 중단되지 않도록 처리

<details>
<summary>사이즈 스펙</summary>

| Size | Height | Corner Radius | Padding (V/H) | Icon Size | Typography |
|:----:|:------:|:-------------:|:-------------:|:---------:|:----------:|
| xsmall | 32px | r16 | 8 / 12 | 16px | label4 |
| small | 36px | r8 | 10 / 14 | 16px | label3 |
| medium | 46px | r10 | 12 / 20 | 20px | label2 |
| large | 56px | r12 | 16 / 24 | 24px | label1 |

> danger variant는 디자인 스펙상 xsmall 미지원

### 컬러 토큰

| Variant | State | Background | Foreground |
|:-------:|:-----:|:----------:|:----------:|
| primary | default | `Bg.Neutral.inverse` | `Fg.Neutral.inverse` |
| primary | highlighted | `Bg.Neutral.Inverse.hover` | `Fg.Neutral.inverse` |
| secondary | default | `Bg.Neutral.subtle` | `Fg.Neutral.bold` |
| secondary | highlighted | `Bg.Neutral.Subtle.hover` | `Fg.Neutral.bold` |
| danger | default | `Bg.Danger.default` | `Fg.Neutral.bold` |
| danger | highlighted | `Bg.Danger.Default.pressed` | `Fg.Neutral.bold` |
| — | disabled | `Bg.Neutral.Default.disabled` | `Fg.Neutral.Default.disabled` |

</details>

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|MDSActionButton|<img width="862" height="238" alt="image" src="https://github.com/user-attachments/assets/a1a3ac8d-f022-4166-9aea-06032ec79c08" />|

## 📮 관련 이슈
- Resolved: #90