### PR TITLE
[Feat] #91 - ActionButton 카탈로그 추가

### DIFF
--- a/MDS/Sources/Components/ActionButton/MDSActionButton.swift
+++ b/MDS/Sources/Components/ActionButton/MDSActionButton.swift
@@ -215,12 +215,12 @@ private extension MDSActionButton {
             switch variant {
             case .primary:
                 background = isHighlighted
-                    ? SemanticColor.Bg.Neutral.Inverse.hover
+                    ? SemanticColor.Bg.Neutral.Inverse.pressed
                     : SemanticColor.Bg.Neutral.inverse
                 foreground = SemanticColor.Fg.Neutral.inverse
             case .secondary:
                 background = isHighlighted
-                    ? SemanticColor.Bg.Neutral.Subtle.hover
+                    ? SemanticColor.Bg.Neutral.Subtle.pressed
                     : SemanticColor.Bg.Neutral.subtle
                 foreground = SemanticColor.Fg.Neutral.bold
             case .danger:

--- a/MDSStoryBook/MDSStoryBook/Component/ActionButton/ActionButtonViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/ActionButton/ActionButtonViewController.swift
@@ -1,0 +1,167 @@
+//
+//  ActionButtonViewController.swift
+//  MDSStoryBook
+//
+//  Created by yungu0010 on 5/25/26.
+//
+
+import UIKit
+import MDS
+
+final class ActionButtonViewController: UIViewController {
+
+    private let scrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.delaysContentTouches = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let contentStack: UIStackView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.spacing = 32
+        view.layoutMargins = UIEdgeInsets(top: 24, left: 20, bottom: 24, right: 20)
+        view.isLayoutMarginsRelativeArrangement = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Action Button"
+        view.backgroundColor = .systemGroupedBackground
+        setupLayout()
+        setupContent()
+    }
+
+    private func setupLayout() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+        ])
+    }
+
+    private func setupContent() {
+        let variants: [(title: String, variant: MDSActionButton.Variant)] = [
+            ("Primary", .primary),
+            ("Secondary", .secondary),
+            ("Danger", .danger),
+        ]
+        variants.forEach { item in
+            contentStack.addArrangedSubview(makeVariantSection(title: item.title, variant: item.variant))
+        }
+    }
+}
+
+// MARK: - Section Builders
+
+private extension ActionButtonViewController {
+
+    // variant 단위 섹션: 타이틀 + Default / Disabled / With Icon 행으로 구성
+    func makeVariantSection(title: String, variant: MDSActionButton.Variant) -> UIView {
+        let sectionTitle = UILabel()
+        sectionTitle.text = title
+        sectionTitle.font = .systemFont(ofSize: 20, weight: .bold)
+        sectionTitle.textColor = .label
+
+        let sectionStack = UIStackView()
+        sectionStack.axis = .vertical
+        sectionStack.spacing = 10
+        sectionStack.addArrangedSubview(sectionTitle)
+
+        let isDanger = variant == .danger
+        let sizes: [MDSActionButton.Size] = isDanger ? [.small, .medium, .large] : [.xsmall, .small, .medium, .large]
+
+        sectionStack.addArrangedSubview(makeRow(label: "Default", variant: variant, sizes: sizes, isEnabled: true))
+        sectionStack.addArrangedSubview(makeRow(label: "Disabled", variant: variant, sizes: sizes, isEnabled: false))
+        sectionStack.addArrangedSubview(makeIconRow(label: "With Icon", variant: variant, sizes: sizes))
+
+        return sectionStack
+    }
+
+    // 지정된 sizes와 enabled 상태의 버튼들을 한 행으로 구성
+    func makeRow(
+        label: String,
+        variant: MDSActionButton.Variant,
+        sizes: [MDSActionButton.Size],
+        isEnabled: Bool
+    ) -> UIView {
+        let buttons: [MDSActionButton] = sizes.map { size in
+            let button = MDSActionButton(variant: variant, size: size)
+            button.title = "Button"
+            button.isEnabled = isEnabled
+            button.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
+            return button
+        }
+        return makeCardRow(label: label, buttons: buttons)
+    }
+
+    // 지원되는 sizes별로 prefix + suffix 아이콘이 적용된 버튼을 한 행으로 구성
+    func makeIconRow(label: String, variant: MDSActionButton.Variant, sizes: [MDSActionButton.Size]) -> UIView {
+        let buttons: [MDSActionButton] = sizes.map { size in
+            let button = MDSActionButton(variant: variant, size: size)
+            button.title = "Button"
+            button.prefixIcon = MDSIcon.plusOutlined.image
+            button.suffixIcon = MDSIcon.chevronRightOutlined.image
+            button.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
+            return button
+        }
+        return makeCardRow(label: label, buttons: buttons)
+    }
+
+    // 레이블 + 카드 컨테이너 + 버튼 목록을 하나의 행으로 조합하는 공통 헬퍼
+    func makeCardRow(label: String, buttons: [MDSActionButton]) -> UIView {
+        let rowLabel = UILabel()
+        rowLabel.text = label
+        rowLabel.font = .systemFont(ofSize: 12, weight: .semibold)
+        rowLabel.textColor = .secondaryLabel
+
+        let card = UIView()
+        card.backgroundColor = SemanticColor.Bg.Dim.default
+        card.layer.cornerRadius = 12
+
+        let buttonRow = UIStackView()
+        buttonRow.axis = .vertical
+        buttonRow.spacing = 12
+        buttonRow.alignment = .leading
+        buttonRow.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        buttonRow.isLayoutMarginsRelativeArrangement = true
+        buttonRow.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(buttonRow)
+
+        NSLayoutConstraint.activate([
+            buttonRow.topAnchor.constraint(equalTo: card.topAnchor),
+            buttonRow.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+            buttonRow.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            buttonRow.trailingAnchor.constraint(lessThanOrEqualTo: card.trailingAnchor),
+        ])
+
+        buttons.forEach { buttonRow.addArrangedSubview($0) }
+
+        let rowStack = UIStackView()
+        rowStack.axis = .vertical
+        rowStack.spacing = 6
+        rowStack.addArrangedSubview(rowLabel)
+        rowStack.addArrangedSubview(card)
+        return rowStack
+    }
+}
+
+// MARK: - Actions
+
+private extension ActionButtonViewController {
+
+    @objc func buttonTapped(_ sender: MDSActionButton) { }
+}

--- a/MDSStoryBook/MDSStoryBook/Component/ComponentCategoryViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/ComponentCategoryViewController.swift
@@ -6,7 +6,6 @@
 import UIKit
 
 final class ComponentCategoryViewController: UIViewController {
-
     private enum Category: String, CaseIterable {
         case chip = "Chip"
         case tag = "Tag"


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#91

## 🌱 PR Point
### ActionButtonViewController 구조

- `makeVariantSection`
  - variant(Primary / Secondary / Danger) 단위 섹션 생성.
  - 섹션 타이틀 + Default / Disabled / With Icon 3개 행으로 구성

- `makeRow`
  - 지정된 sizes와 enabled 상태의 버튼들을 한 행으로 구성

- `makeIconRow`
  - 지원되는 sizes별로 prefix + suffix 아이콘이 적용된 버튼을 한 행으로 구성

- `makeCardRow
  - 레이블 + 카드 컨테이너 + 버튼 목록을 하나의 행으로 조합하는 공통 헬퍼

### Button 카테고리 계층 추가
기존 Component 목록에 Button 카테고리를 추가하고, 그 하위에 Action Button을 배치했습니다.
- `ComponentCategoryViewController` → `ButtonCategoryViewController` → `ActionButtonViewController`

## 📌 참고 사항
- danger variant는 디자인 스펙상 xsmall 미지원으로, Default / Disabled / With Icon 모두 small, medium, large만 표시
- `scrollView.delaysContentTouches = false` 설정: 스크롤뷰 내 버튼 터치가 바로 반응할 수 있도록

## 📸 스크린샷
https://github.com/user-attachments/assets/251ddab1-e660-4937-87e6-1799d9e0b4ff

## 📮 관련 이슈
- Resolved: #91