### PR TITLE
[Feat] #94 - MDSFloatingButton 컴포넌트 구현

### DIFF
--- a/MDS/Sources/Components/ActionButton/MDSActionButtonType.swift
+++ b/MDS/Sources/Components/ActionButton/MDSActionButtonType.swift
@@ -7,13 +7,13 @@
 
 public extension MDSActionButton {
 
-    enum Variant {
+    public enum Variant {
         case primary
         case secondary
         case danger
     }
 
-    enum Size {
+    public enum Size {
         case xsmall
         case small
         case medium

--- a/MDS/Sources/Components/FloatingButton/MDSFloatingButton.swift
+++ b/MDS/Sources/Components/FloatingButton/MDSFloatingButton.swift
@@ -1,0 +1,187 @@
+//
+//  MDSFloatingButton.swift
+//  MDS
+//
+//  Created by yungu0010 on 5/31/26.
+//
+
+import UIKit
+
+public final class MDSFloatingButton: UIControl {
+
+    // MARK: - Properties
+
+    public var icon: UIImage? {
+        didSet {
+            iconImageView.image = icon?.withRenderingMode(.alwaysTemplate)
+        }
+    }
+
+    public var label: String? {
+        didSet { updateAppearance() }
+    }
+
+    public override var isHighlighted: Bool {
+        didSet { updateAppearance() }
+    }
+
+    public override var isEnabled: Bool {
+        didSet { updateAppearance() }
+    }
+
+    private let size: Size
+
+    // MARK: - Subviews
+
+    private let contentStackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .horizontal
+        view.alignment = .center
+        view.isUserInteractionEnabled = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let iconImageView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFit
+        return view
+    }()
+
+    private let titleLabel: UILabel = {
+        let view = UILabel()
+        view.numberOfLines = 1
+        return view
+    }()
+
+    // MARK: - Init
+
+    public init(size: Size = .default, icon: UIImage? = nil, label: String? = nil) {
+        self.size = size
+        self.icon = icon
+        self.label = label
+        super.init(frame: .zero)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - Setup
+
+    private func setup() {
+        setupHierarchy()
+        setupLayout()
+        updateAppearance()
+    }
+
+    private func setupHierarchy() {
+        let sizeToken = SizeToken(size: size)
+        layer.cornerRadius = sizeToken.cornerRadius
+        layer.masksToBounds = true
+
+        contentStackView.spacing = sizeToken.iconGap
+        contentStackView.addArrangedSubview(iconImageView)
+        contentStackView.addArrangedSubview(titleLabel)
+        addSubview(contentStackView)
+
+        iconImageView.image = icon?.withRenderingMode(.alwaysTemplate)
+    }
+
+    private func setupLayout() {
+        let sizeToken = SizeToken(size: size)
+        let insets = sizeToken.contentInsets
+        let iconSize = sizeToken.iconSize
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: 48),
+
+            contentStackView.topAnchor.constraint(equalTo: topAnchor, constant: insets.top),
+            contentStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -insets.bottom),
+            contentStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: insets.leading),
+            contentStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -insets.trailing),
+
+            iconImageView.widthAnchor.constraint(equalToConstant: iconSize),
+            iconImageView.heightAnchor.constraint(equalToConstant: iconSize),
+        ])
+
+        if size == .default {
+            NSLayoutConstraint.activate([
+                widthAnchor.constraint(equalToConstant: 48),
+            ])
+        }
+    }
+
+    // MARK: - Appearance
+
+    private func updateAppearance() {
+        let colorToken = ColorToken(isHighlighted: isHighlighted, isEnabled: isEnabled)
+        let sizeToken = SizeToken(size: size)
+
+        backgroundColor = colorToken.background
+        iconImageView.tintColor = colorToken.foreground
+
+        let hasLabel = !(label?.isEmpty ?? true)
+        titleLabel.isHidden = (size == .default) || !hasLabel
+
+        titleLabel.attributedText = NSAttributedString(
+            string: label ?? "",
+            attributes: [
+                .font: sizeToken.typography.font,
+                .kern: sizeToken.typography.letterSpacing,
+                .foregroundColor: colorToken.foreground,
+            ]
+        )
+    }
+}
+
+// MARK: - Size Token
+
+private extension MDSFloatingButton {
+
+    struct SizeToken {
+        let cornerRadius: CGFloat
+        let contentInsets: NSDirectionalEdgeInsets
+        let iconSize: CGFloat
+        let iconGap: CGFloat
+        let typography: MDSFont
+
+        init(size: MDSFloatingButton.Size) {
+            cornerRadius = BaseRadius.Base.r16
+            switch size {
+            case .default:
+                contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
+                iconSize = 28
+                iconGap = 0
+                typography = Typography.label1
+            case .extended:
+                contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 14, bottom: 12, trailing: 14)
+                iconSize = 24
+                iconGap = 4
+                typography = Typography.label1
+            }
+        }
+    }
+}
+
+// MARK: - Color Token
+
+private extension MDSFloatingButton {
+
+    struct ColorToken {
+        let background: UIColor
+        let foreground: UIColor
+
+        init(isHighlighted: Bool, isEnabled: Bool) {
+            guard isEnabled else {
+                background = SemanticColor.Bg.Neutral.Default.disabled
+                foreground = SemanticColor.Fg.Neutral.Default.disabled
+                return
+            }
+            background = isHighlighted
+                ? SemanticColor.Bg.Neutral.Inverse.hover
+                : SemanticColor.Bg.Neutral.inverse
+            foreground = SemanticColor.Fg.Neutral.inverse
+        }
+    }
+}

--- a/MDS/Sources/Components/FloatingButton/MDSFloatingButtonType.swift
+++ b/MDS/Sources/Components/FloatingButton/MDSFloatingButtonType.swift
@@ -1,0 +1,14 @@
+//
+//  MDSFloatingButtonType.swift
+//  MDS
+//
+//  Created by yungu0010 on 5/31/26.
+//
+
+public extension MDSFloatingButton {
+
+    public enum Size {
+        case `default`
+        case extended
+    }
+}

--- a/MDS/Sources/Components/Tag/MDSTagType.swift
+++ b/MDS/Sources/Components/Tag/MDSTagType.swift
@@ -7,19 +7,19 @@
 
 public extension MDSTag {
 
-    enum Size {
+    public enum Size {
         case small, medium, large
     }
 
-    enum Shape {
+    public enum Shape {
         case rect, pill
     }
 
-    enum Variant {
+    public enum Variant {
         case `default`, primary, secondary
     }
 
-    enum Style {
+    public enum Style {
         case solid, subtle
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#94

## 🌱 PR Point

### UIControl + UIStackView 선택 이유

`MDSActionButton`과 동일한 이유로 UIControl + UIStackView를 채택했습니다.
- `extended` size는 아이콘과 텍스트 레이블을 함께 표시하며, UIStackView가 레이아웃을 자동으로 처리합니다.
- 탭 이벤트는 `UIControl`의 `addTarget(_:action:for:)` 으로 사용할 수 있습니다.

### init 파라미터 + public property

선언 시점에 한 줄로 구성할 수 있도록 `icon`과 `label`을 init 파라미터로 제공하며, 동적 업데이트를 위한 public property도 함께 열어두었습니다.

```swift
// 선언 시점
let button = MDSFloatingButton(size: .extended, icon: MDSIcon.plusOutlined.image, label: "글쓰기")

// 동적 업데이트
button.label = "새 글쓰기"
```

### titleLabel 동적 isHidden 처리

`extended` size에서 `label`이 nil이거나 빈 문자열인 경우 `titleLabel`을 숨겨 아이콘이 중앙에서 벗어나는 레이아웃 버그를 방지합니다. `updateAppearance()` 내에서 동적으로 처리합니다.

```swift
let hasLabel = !(label?.isEmpty ?? true)
titleLabel.isHidden = (size == .default) || !hasLabel
```

### public 접근 제어 수정

`public init` 시그니처에 등장하는 타입은 반드시 `public`이어야 외부 모듈에서 접근할 수 있습니다.`MDSFloatingButtonType`, `MDSActionButtonType`, `MDSTagType`의 enum은 public extension에 포함되어있으나 명시적으로 표현하기 위해 `public`을 추가했습니다.

<details><summary>버튼 스펙</summary>

### 사이즈 스펙

| Size | 크기 | Padding | Icon 크기 | Corner Radius |
|:----:|:----:|:-------:|:---------:|:-------------:|
| default | 48×48px | 10px (all) | 28px | r16 |
| extended | height 48px | 12px(V) / 14px(H) | 24px | r16 |

> extended: 아이콘-텍스트 간격 4px, typography label1 (18px SemiBold)

### 컬러 토큰

| 상태 | Background | Foreground |
|:----:|:----------:|:----------:|
| default | `Bg.Neutral.inverse` | `Fg.Neutral.inverse` |
| press | `Bg.Neutral.Inverse.hover` | `Fg.Neutral.inverse` |
| disabled | `Bg.Neutral.Default.disabled` | `Fg.Neutral.Default.disabled` |

</details>

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #94