### PR TITLE
[Feat] #96 - Floating Button 카탈로그 추가

### DIFF
--- a/MDSStoryBook/MDSStoryBook/Component/Button/ButtonCategoryViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/Button/ButtonCategoryViewController.swift
@@ -9,7 +9,12 @@ import UIKit
 
 final class ButtonCategoryViewController: UIViewController {
 
-    private let categories = ["Action Button", "Floating Button"]
+    private enum Category: String, CaseIterable {
+        case actionButton = "Action Button"
+        case floatingButton = "Floating Button"
+    }
+
+    private let categories = Category.allCases
 
     private let tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .insetGrouped)
@@ -51,7 +56,7 @@ extension ButtonCategoryViewController: UITableViewDataSource, UITableViewDelega
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "CategoryCell", for: indexPath)
-        cell.textLabel?.text = categories[indexPath.row]
+        cell.textLabel?.text = categories[indexPath.row].rawValue
         cell.accessoryType = .disclosureIndicator
         return cell
     }
@@ -59,12 +64,10 @@ extension ButtonCategoryViewController: UITableViewDataSource, UITableViewDelega
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         switch categories[indexPath.row] {
-        case "Action Button":
+        case .actionButton:
             navigationController?.pushViewController(ActionButtonViewController(), animated: true)
-        case "Floating Button":
+        case .floatingButton:
             navigationController?.pushViewController(FloatingButtonViewController(), animated: true)
-        default:
-            break
         }
     }
 }

--- a/MDSStoryBook/MDSStoryBook/Component/Button/ButtonCategoryViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/Button/ButtonCategoryViewController.swift
@@ -1,12 +1,15 @@
 //
-//  ComponentCategoryViewController.swift
+//  ButtonCategoryViewController.swift
 //  MDSStoryBook
+//
+//  Created by yungu0010 on 5/25/26.
 //
 
 import UIKit
 
-final class ComponentCategoryViewController: UIViewController {
-    private let categories = ["Chip", "Tag", "Callout", "Button"]
+final class ButtonCategoryViewController: UIViewController {
+
+    private let categories = ["Action Button", "Floating Button"]
 
     private let tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .insetGrouped)
@@ -17,7 +20,7 @@ final class ComponentCategoryViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Component"
+        title = "Button"
         view.backgroundColor = .systemGroupedBackground
         setupLayout()
         setupTableView()
@@ -40,7 +43,8 @@ final class ComponentCategoryViewController: UIViewController {
     }
 }
 
-extension ComponentCategoryViewController: UITableViewDataSource, UITableViewDelegate {
+extension ButtonCategoryViewController: UITableViewDataSource, UITableViewDelegate {
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         categories.count
     }
@@ -55,14 +59,10 @@ extension ComponentCategoryViewController: UITableViewDataSource, UITableViewDel
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         switch categories[indexPath.row] {
-        case "Chip":
-            navigationController?.pushViewController(ChipViewController(), animated: true)
-        case "Tag":
-            navigationController?.pushViewController(TagViewController(), animated: true)
-        case "Callout":
-            navigationController?.pushViewController(CalloutViewController(), animated: true)
-        case "Button":
-            navigationController?.pushViewController(ButtonCategoryViewController(), animated: true)
+        case "Action Button":
+            navigationController?.pushViewController(ActionButtonViewController(), animated: true)
+        case "Floating Button":
+            navigationController?.pushViewController(FloatingButtonViewController(), animated: true)
         default:
             break
         }

--- a/MDSStoryBook/MDSStoryBook/Component/Button/FloatingButtonViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/Button/FloatingButtonViewController.swift
@@ -1,0 +1,126 @@
+//
+//  FloatingButtonViewController.swift
+//  MDSStoryBook
+//
+//  Created by yungu0010 on 5/31/26.
+//
+
+import UIKit
+import MDS
+
+final class FloatingButtonViewController: UIViewController {
+
+    // MARK: - Subviews
+
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.delaysContentTouches = false
+        return scrollView
+    }()
+
+    private let contentStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 32
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.layoutMargins = UIEdgeInsets(top: 24, left: 20, bottom: 40, right: 20)
+        return stackView
+    }()
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Floating Button"
+        view.backgroundColor = .systemGroupedBackground
+        setupLayout()
+        setupContent()
+    }
+
+    // MARK: - Setup
+
+    private func setupLayout() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStackView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentStackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentStackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+        ])
+    }
+
+    private func setupContent() {
+        contentStackView.addArrangedSubview(makeSizeSection(size: .default))
+        contentStackView.addArrangedSubview(makeSizeSection(size: .extended))
+    }
+
+    // MARK: - Section Builders
+
+    private func makeSizeSection(size: MDSFloatingButton.Size) -> UIView {
+        let sectionTitle = size == .default ? "Default" : "Extended"
+
+        let titleLabel = UILabel()
+        titleLabel.text = sectionTitle
+        titleLabel.font = .systemFont(ofSize: 20, weight: .bold)
+        titleLabel.textColor = .label
+
+        let icon = UIImage(systemName: "plus")
+        let label = size == .extended ? "추가하기" : nil
+
+        let defaultButton = MDSFloatingButton(size: size, icon: icon, label: label)
+        let disabledButton = MDSFloatingButton(size: size, icon: icon, label: label)
+        disabledButton.isEnabled = false
+
+        let rows: [(String, MDSFloatingButton)] = [
+            ("Default", defaultButton),
+            ("Disabled", disabledButton),
+        ]
+
+        let sectionStack = UIStackView()
+        sectionStack.axis = .vertical
+        sectionStack.spacing = 8
+        sectionStack.addArrangedSubview(titleLabel)
+        for (label, button) in rows {
+            sectionStack.addArrangedSubview(makeRow(label: label, button: button))
+        }
+
+        return sectionStack
+    }
+
+    private func makeRow(label: String, button: MDSFloatingButton) -> UIView {
+        let stateLabel = UILabel()
+        stateLabel.text = label
+        stateLabel.font = .systemFont(ofSize: 12, weight: .semibold)
+        stateLabel.textColor = .secondaryLabel
+
+        let card = UIView()
+        card.backgroundColor = SemanticColor.Bg.Dim.default
+        card.layer.cornerRadius = 12
+
+        button.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(button)
+
+        NSLayoutConstraint.activate([
+            button.topAnchor.constraint(equalTo: card.topAnchor, constant: 16),
+            button.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -16),
+            button.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 16),
+        ])
+
+        let container = UIStackView()
+        container.axis = .vertical
+        container.spacing = 6
+        container.addArrangedSubview(stateLabel)
+        container.addArrangedSubview(card)
+        return container
+    }
+}

--- a/MDSStoryBook/MDSStoryBook/Component/ComponentCategoryViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/ComponentCategoryViewController.swift
@@ -6,7 +6,15 @@
 import UIKit
 
 final class ComponentCategoryViewController: UIViewController {
-    private let categories = ["Chip", "Tag", "Callout", "Button"]
+
+    private enum Category: String, CaseIterable {
+        case chip = "Chip"
+        case tag = "Tag"
+        case callout = "Callout"
+        case button = "Button"
+    }
+
+    private let categories = Category.allCases
 
     private let tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .insetGrouped)
@@ -47,7 +55,7 @@ extension ComponentCategoryViewController: UITableViewDataSource, UITableViewDel
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "CategoryCell", for: indexPath)
-        cell.textLabel?.text = categories[indexPath.row]
+        cell.textLabel?.text = categories[indexPath.row].rawValue
         cell.accessoryType = .disclosureIndicator
         return cell
     }
@@ -55,16 +63,14 @@ extension ComponentCategoryViewController: UITableViewDataSource, UITableViewDel
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         switch categories[indexPath.row] {
-        case "Chip":
+        case .chip:
             navigationController?.pushViewController(ChipViewController(), animated: true)
-        case "Tag":
+        case .tag:
             navigationController?.pushViewController(TagViewController(), animated: true)
-        case "Callout":
+        case .callout:
             navigationController?.pushViewController(CalloutViewController(), animated: true)
-        case "Button":
+        case .button:
             navigationController?.pushViewController(ButtonCategoryViewController(), animated: true)
-        default:
-            break
         }
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#96

## 🌱 PR Point
- Floating Button 카탈로그 메뉴를 추가했습니다.
- `ComponentCategoryViewController`, `ButtonCategoryViewController` 카테고리 관리를 `CaseIterable` enum으로 변경
- 문자열 하드코딩 제거 및 `default` 분기 없이 exhaustive switch 처리

## 📌 참고 사항
- `ButtonCategoryViewController.swift`, `ComponentCategoryViewController.swift` 변경분만 cherry-pick (76cdee3)

## 📸 스크린샷

https://github.com/user-attachments/assets/6226a24f-b673-4c02-ac35-ac1286db1a74



## 📮 관련 이슈

- Resolved: #96