### PR TITLE
[Feat] #101 - MDSActionButton init 파라미터 추가

### DIFF
--- a/MDS/Sources/Components/ActionButton/MDSActionButton.swift
+++ b/MDS/Sources/Components/ActionButton/MDSActionButton.swift
@@ -16,17 +16,11 @@ public final class MDSActionButton: UIControl {
     }
 
     public var prefixIcon: UIImage? {
-        didSet {
-            prefixImageView.image = prefixIcon?.withRenderingMode(.alwaysTemplate)
-            prefixImageView.isHidden = prefixIcon == nil
-        }
+        didSet { updateAppearance() }
     }
 
     public var suffixIcon: UIImage? {
-        didSet {
-            suffixImageView.image = suffixIcon?.withRenderingMode(.alwaysTemplate)
-            suffixImageView.isHidden = suffixIcon == nil
-        }
+        didSet { updateAppearance() }
     }
 
     public override var isHighlighted: Bool {
@@ -74,7 +68,13 @@ public final class MDSActionButton: UIControl {
 
     // MARK: - Init
 
-    public init(variant: Variant = .primary, size: Size = .large) {
+    public init(
+        variant: Variant = .primary,
+        size: Size = .large,
+        title: String? = nil,
+        prefixIcon: UIImage? = nil,
+        suffixIcon: UIImage? = nil
+    ) {
         self.variant = variant
         if variant == .danger && size == .xsmall {
             assertionFailure("MDSActionButton: danger variant은 xsmall size를 지원하지 않습니다.")
@@ -82,6 +82,9 @@ public final class MDSActionButton: UIControl {
         } else {
             self.size = size
         }
+        self.title = title
+        self.prefixIcon = prefixIcon
+        self.suffixIcon = suffixIcon
         super.init(frame: .zero)
         setup()
     }
@@ -99,9 +102,6 @@ public final class MDSActionButton: UIControl {
 
     private func setupHierarchy() {
         let sizeToken = SizeToken(size: size)
-        layer.cornerRadius = sizeToken.cornerRadius
-        layer.masksToBounds = true
-
         contentStackView.spacing = sizeToken.iconGap
         contentStackView.addArrangedSubview(prefixImageView)
         contentStackView.addArrangedSubview(titleLabel)
@@ -113,6 +113,9 @@ public final class MDSActionButton: UIControl {
         let sizeToken = SizeToken(size: size)
         let insets = sizeToken.contentInsets
         let iconSize = sizeToken.iconSize
+
+        layer.cornerRadius = sizeToken.cornerRadius
+        layer.masksToBounds = true
 
         NSLayoutConstraint.activate([
             heightAnchor.constraint(equalToConstant: sizeToken.height),
@@ -146,7 +149,12 @@ public final class MDSActionButton: UIControl {
             ]
         )
 
+        prefixImageView.image = prefixIcon?.withRenderingMode(.alwaysTemplate)
+        prefixImageView.isHidden = prefixIcon == nil
         prefixImageView.tintColor = colorToken.foreground
+
+        suffixImageView.image = suffixIcon?.withRenderingMode(.alwaysTemplate)
+        suffixImageView.isHidden = suffixIcon == nil
         suffixImageView.tintColor = colorToken.foreground
     }
 }

--- a/MDSStoryBook/MDSStoryBook/Component/ActionButton/ActionButtonViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/ActionButton/ActionButtonViewController.swift
@@ -99,8 +99,7 @@ private extension ActionButtonViewController {
         isEnabled: Bool
     ) -> UIView {
         let buttons: [MDSActionButton] = sizes.map { size in
-            let button = MDSActionButton(variant: variant, size: size)
-            button.title = "Button"
+            let button = MDSActionButton(variant: variant, size: size, title: "Button")
             button.isEnabled = isEnabled
             button.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
             return button
@@ -111,10 +110,13 @@ private extension ActionButtonViewController {
     // 지원되는 sizes별로 prefix + suffix 아이콘이 적용된 버튼을 한 행으로 구성
     func makeIconRow(label: String, variant: MDSActionButton.Variant, sizes: [MDSActionButton.Size]) -> UIView {
         let buttons: [MDSActionButton] = sizes.map { size in
-            let button = MDSActionButton(variant: variant, size: size)
-            button.title = "Button"
-            button.prefixIcon = MDSIcon.plusOutlined.image
-            button.suffixIcon = MDSIcon.chevronRightOutlined.image
+            let button = MDSActionButton(
+                variant: variant,
+                size: size,
+                title: "Button",
+                prefixIcon: MDSIcon.plusOutlined.image,
+                suffixIcon: MDSIcon.chevronRightOutlined.image
+            )
             button.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
             return button
         }


### PR DESCRIPTION
## 🌴 PR 요약
- ActionButton의 init 방식을 수정했습니다.

🌱 작업한 브랜치
- feat/#101

## 🌱 PR Point

**1. `init` 파라미터 추가**

| AS-IS | TO-BE |
|---|---|
| `init(variant:size:)` | `init(variant:size:title:prefixIcon:suffixIcon:)` |

모든 파라미터에 기본값을 제공해 기존 코드와 하위 호환 유지

**2. 관심사 분리**

| 항목 | AS-IS | TO-BE |
|---|---|---|
| `cornerRadius`, `masksToBounds` | `setupHierarchy()` → `updateAppearance()` | `setupLayout()` (최초 1회) |
| `image`, `isHidden` | `setupHierarchy()` + `didSet` 직접 처리 | `updateAppearance()` |
| `prefixIcon` / `suffixIcon` `didSet` | 직접 `image`, `isHidden` 설정 | `updateAppearance()` 호출로 통일 |

- `setupHierarchy()`: 뷰 계층 구성만 담당
- `setupLayout()`: 제약 + 불변 스타일(cornerRadius) 설정
- `updateAppearance()`: 상태에 따라 변하는 시각적 속성만 담당

## 📌 참고 사항
없음

## 📸 스크린샷
없음

## 📮 관련 이슈

- Resolved: #101