### PR TITLE
[Feat] #113 - RadioButton 구현

### DIFF
--- a/MDS/Sources/Components/Control/RadioButton/MDSRadioButton.swift
+++ b/MDS/Sources/Components/Control/RadioButton/MDSRadioButton.swift
@@ -1,0 +1,209 @@
+//
+//  MDSRadioButton.swift
+//  MDS
+//
+
+import UIKit
+
+public final class MDSRadioButton: UIControl {
+
+    // MARK: - Properties
+
+    public override var isSelected: Bool {
+        didSet { updateCircle(colorToken: ColorToken(isEnabled: isEnabled, isSelected: isSelected)) }
+    }
+
+    public override var isEnabled: Bool {
+        didSet {
+            let colorToken = ColorToken(isEnabled: isEnabled, isSelected: isSelected)
+            updateCircle(colorToken: colorToken)
+            updateLabel(colorToken: colorToken)
+        }
+    }
+
+    public var labelText: String? {
+        didSet { updateLabel(colorToken: ColorToken(isEnabled: isEnabled, isSelected: isSelected)) }
+    }
+
+    private let sizeToken: SizeToken
+
+    // MARK: - UI Components
+
+    private let stackView: UIStackView = {
+        let sv = UIStackView()
+        sv.axis = .horizontal
+        sv.alignment = .center
+        sv.isUserInteractionEnabled = false
+        sv.translatesAutoresizingMaskIntoConstraints = false
+        return sv
+    }()
+
+    private let circleView: UIView = {
+        let view = UIView()
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+
+    private let dotView: UIView = {
+        let view = UIView()
+        view.isUserInteractionEnabled = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        label.isUserInteractionEnabled = false
+        return label
+    }()
+
+    // MARK: - Init
+
+    public init(size: Size = .large) {
+        self.sizeToken = SizeToken(size: size)
+        super.init(frame: .zero)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - Setup
+
+    private func setup() {
+        setupHierarchy()
+        setupLayout()
+        addTarget(self, action: #selector(handleTap), for: .touchUpInside)
+        let colorToken = ColorToken(isEnabled: isEnabled, isSelected: isSelected)
+        updateCircle(colorToken: colorToken)
+        updateLabel(colorToken: colorToken)
+    }
+
+    private func setupHierarchy() {
+        addSubview(stackView)
+        stackView.addArrangedSubview(circleView)
+        stackView.addArrangedSubview(titleLabel)
+        circleView.addSubview(dotView)
+    }
+
+    private func setupLayout() {
+        stackView.spacing = sizeToken.gap
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            circleView.widthAnchor.constraint(equalToConstant: sizeToken.circleSize),
+            circleView.heightAnchor.constraint(equalToConstant: sizeToken.circleSize),
+
+            dotView.centerXAnchor.constraint(equalTo: circleView.centerXAnchor),
+            dotView.centerYAnchor.constraint(equalTo: circleView.centerYAnchor),
+            dotView.widthAnchor.constraint(equalToConstant: sizeToken.dotSize),
+            dotView.heightAnchor.constraint(equalToConstant: sizeToken.dotSize),
+        ])
+
+        circleView.layer.cornerRadius = sizeToken.circleSize / 2
+        dotView.layer.cornerRadius = sizeToken.dotSize / 2
+    }
+
+    @objc private func handleTap() {
+        isSelected.toggle()
+        sendActions(for: .valueChanged)
+    }
+
+    // MARK: - Appearance
+
+    private func updateCircle(colorToken: ColorToken) {
+        circleView.backgroundColor = colorToken.circleFillColor
+        circleView.layer.borderColor = colorToken.circleBorderColor.cgColor
+        circleView.layer.borderWidth = colorToken.circleBorderWidth
+        dotView.backgroundColor = colorToken.dotColor
+        dotView.isHidden = !isSelected
+    }
+
+    private func updateLabel(colorToken: ColorToken) {
+        guard let text = labelText, !text.isEmpty else {
+            titleLabel.isHidden = true
+            return
+        }
+        titleLabel.isHidden = false
+        titleLabel.attributedText = NSAttributedString(
+            string: text,
+            attributes: [
+                .font: sizeToken.typography.font,
+                .kern: sizeToken.typography.letterSpacing,
+                .foregroundColor: colorToken.labelColor
+            ]
+        )
+    }
+}
+
+// MARK: - SizeToken
+
+extension MDSRadioButton {
+    struct SizeToken {
+        let circleSize: CGFloat
+        let dotSize: CGFloat
+        let gap: CGFloat
+        let typography: MDSFont
+
+        init(size: Size) {
+            switch size {
+            case .small:
+                circleSize = 22
+                dotSize = 8
+                gap = 4
+                typography = Typography.label3
+            case .large:
+                circleSize = 26
+                dotSize = 10
+                gap = 8
+                typography = Typography.label2
+            }
+        }
+    }
+}
+
+// MARK: - ColorToken
+
+extension MDSRadioButton {
+    struct ColorToken {
+        let circleFillColor: UIColor
+        let circleBorderColor: UIColor
+        let circleBorderWidth: CGFloat
+        let dotColor: UIColor
+        let labelColor: UIColor
+
+        init(isEnabled: Bool, isSelected: Bool) {
+            switch (isEnabled, isSelected) {
+            case (true, false):
+                circleFillColor = .clear
+                circleBorderColor = SemanticColor.Stroke.Neutral.default
+                circleBorderWidth = 1.5
+                dotColor = .clear
+                labelColor = SemanticColor.Fg.Neutral.bold
+            case (true, true):
+                circleFillColor = SemanticColor.Fg.Secondary.default
+                circleBorderColor = .clear
+                circleBorderWidth = 0
+                dotColor = SemanticColor.Fg.Neutral.bold
+                labelColor = SemanticColor.Fg.Neutral.bold
+            case (false, false):
+                circleFillColor = .clear
+                circleBorderColor = SemanticColor.Stroke.Neutral.Default.disabled
+                circleBorderWidth = 1.5
+                dotColor = .clear
+                labelColor = SemanticColor.Fg.Neutral.Default.disabled
+            case (false, true):
+                circleFillColor = SemanticColor.Fg.Neutral.Ghost.disabled
+                circleBorderColor = .clear
+                circleBorderWidth = 0
+                dotColor = SemanticColor.Fg.Neutral.Default.disabled
+                labelColor = SemanticColor.Fg.Neutral.Default.disabled
+            }
+        }
+    }
+}

--- a/MDS/Sources/Components/Control/RadioButton/MDSRadioButton.swift
+++ b/MDS/Sources/Components/Control/RadioButton/MDSRadioButton.swift
@@ -60,9 +60,10 @@ public final class MDSRadioButton: UIControl {
 
     // MARK: - Init
 
-    public init(size: Size = .large) {
+    public init(size: Size = .large, label: String? = nil) {
         self.sizeToken = SizeToken(size: size)
         super.init(frame: .zero)
+        self.labelText = label
         setup()
     }
 
@@ -110,7 +111,8 @@ public final class MDSRadioButton: UIControl {
     }
 
     @objc private func handleTap() {
-        isSelected.toggle()
+        guard !isSelected else { return }
+        isSelected = true
         sendActions(for: .valueChanged)
     }
 

--- a/MDS/Sources/Components/Control/RadioButton/MDSRadioButtonType.swift
+++ b/MDS/Sources/Components/Control/RadioButton/MDSRadioButtonType.swift
@@ -1,0 +1,13 @@
+//
+//  MDSRadioButtonType.swift
+//  MDS
+//
+
+import Foundation
+
+public extension MDSRadioButton {
+    enum Size {
+        case small
+        case large
+    }
+}


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#113

## 🌱 PR Point

**구현 방식**
- UIKit에 네이티브 라디오버튼이 없어 `circleView` 위에 `dotView`를 올리는 방식으로 구현했습니다.
- `UIButton`에 상태별 이미지를 설정하는 방법도 있지만, 이미지를 코드로 직접 생성해야 해서 코드량이 더 많아집니다.
- 두 뷰를 분리하면 각 역할이 명확하고 상태 변화 시 개별 제어가 쉽다고 판단했습니다.

**업데이트 함수 분리**
- `updateCircle(colorToken:)`과 `updateLabel(colorToken:)`로 분리했습니다.
- 라벨 색상은 `isEnabled`에만 영향을 받고 `isSelected`와 무관하기 때문에,
- `isSelected` 변경 시에는 `updateCircle`만, `isEnabled` 변경 시에는 `ColorToken`을 한 번만 생성해 두 함수에 공유합니다.

**사용 방법**
```swift
let radio = MDSRadioButton(size: .large, label: "Label")
radio.isSelected = true
radio.isEnabled = false

radio.addTarget(self, action: #selector(radioTapped), for: .valueChanged)   // toggle과 컨벤션 통일
```

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
생략. 스토리보드 PR에 첨부 예정

## 📮 관련 이슈
- Resolved: #113