### PR TITLE
[Feat] #115 - RadioGroup 구현

### DIFF
--- a/MDS/Sources/Components/Control/RadioButton/MDSRadioButton.swift
+++ b/MDS/Sources/Components/Control/RadioButton/MDSRadioButton.swift
@@ -110,7 +110,8 @@ public final class MDSRadioButton: UIControl {
     }
 
     @objc private func handleTap() {
-        isSelected.toggle()
+        guard !isSelected else { return }
+        isSelected = true
         sendActions(for: .valueChanged)
     }
 

--- a/MDS/Sources/Components/Control/RadioButton/MDSRadioGroup.swift
+++ b/MDS/Sources/Components/Control/RadioButton/MDSRadioGroup.swift
@@ -1,0 +1,40 @@
+//
+//  MDSRadioGroup.swift
+//  MDS
+//
+
+import UIKit
+
+public final class MDSRadioGroup {
+
+    // MARK: - Properties
+
+    public var onSelectionChanged: ((Int) -> Void)?
+
+    private var buttons: [MDSRadioButton] = []
+
+    // MARK: - Init
+
+    public init() {}
+
+    // MARK: - Interface
+
+    public func add(_ button: MDSRadioButton) {
+        buttons.append(button)
+        button.addAction(UIAction { [weak self] _ in
+            self?.radioTapped(button)
+        }, for: .valueChanged)
+    }
+
+    public func add(_ buttons: [MDSRadioButton]) {
+        buttons.forEach { add($0) }
+    }
+
+    // MARK: - Action
+
+    private func radioTapped(_ sender: MDSRadioButton) {
+        buttons.forEach { $0.isSelected = ($0 === sender) }
+        guard let index = buttons.firstIndex(where: { $0 === sender }) else { return }
+        onSelectionChanged?(index)
+    }
+}

--- a/MDS/Sources/Components/Control/RadioButton/MDSRadioGroup.swift
+++ b/MDS/Sources/Components/Control/RadioButton/MDSRadioGroup.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+@MainActor
 public final class MDSRadioGroup {
 
     // MARK: - Properties


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#115

## 🌱 PR Point

**구현 방식**
`MDSRadioGroup`은 UIView가 아닌 순수 클래스로, 단일선택 보장 로직만 담당합니다.
레이아웃은 사용하는 쪽에서 결정하도록 분리했습니다.
가로 배치 시 줄바꿈 케이스 등 레이아웃 엣지 케이스를 그룹이 책임지면 복잡도가 커지기 때문입니다.

**사용 방법**
```swift
let group = MDSRadioGroup()
group.add([radio1, radio2, radio3])

// 레이아웃은 사용하는 쪽에서 자유롭게
let stack = UIStackView(arrangedSubviews: [radio1, radio2, radio3])
stack.axis = .vertical

group.onSelectionChanged = { index in
    print("선택된 인덱스: \(index)")
}
```

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #115