### PR TITLE
[Feat] #117 - MDSAvatar 구현

### DIFF
--- a/MDS/Sources/Components/Avatar/MDSAvatar.swift
+++ b/MDS/Sources/Components/Avatar/MDSAvatar.swift
@@ -1,0 +1,107 @@
+//
+//  MDSAvatar.swift
+//  MDS
+//
+
+import UIKit
+
+public final class MDSAvatar: UIView {
+
+    // MARK: - Private Views
+
+    private let profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let fallbackIconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    // MARK: - Properties
+
+    public var image: UIImage? {
+        didSet { applyImageState() }
+    }
+
+    public var hasStroke: Bool {
+        didSet { layer.borderWidth = hasStroke ? strokeWeight : 0 }
+    }
+
+    private let size: CGFloat
+
+    // MARK: - Init
+
+    /// - Parameter size: 권고 사이즈 — 24, 32, 48, 56, 72, 80, 120, 180 (단위: pt)
+    public init(size: CGFloat, image: UIImage? = nil, hasStroke: Bool = false) {
+        self.size = size
+        self.image = image
+        self.hasStroke = hasStroke
+        super.init(frame: .zero)
+        setupUI()
+        setupLayout()
+        applyImageState()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - Layout
+
+    public override var intrinsicContentSize: CGSize {
+        CGSize(width: size, height: size)
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        layer.cornerRadius = size / 2
+        layer.borderWidth = hasStroke ? strokeWeight : 0
+        layer.borderColor = SemanticColor.Stroke.Secondary.default.cgColor
+        layer.masksToBounds = true
+
+        backgroundColor = SemanticColor.Bg.Neutral.ghost
+
+        fallbackIconView.image = MDSIcon.userFilled.image.withRenderingMode(.alwaysTemplate)
+        fallbackIconView.tintColor = SemanticColor.Fg.Neutral.bold
+    }
+
+    private func setupLayout() {
+        addSubview(profileImageView)
+        NSLayoutConstraint.activate([
+            profileImageView.topAnchor.constraint(equalTo: topAnchor),
+            profileImageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            profileImageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            profileImageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+
+        addSubview(fallbackIconView)
+        NSLayoutConstraint.activate([
+            fallbackIconView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            fallbackIconView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            fallbackIconView.widthAnchor.constraint(equalToConstant: size / 2),
+            fallbackIconView.heightAnchor.constraint(equalToConstant: size / 2)
+        ])
+    }
+
+    // MARK: - Apply
+
+    private func applyImageState() {
+        let hasImage = image != nil
+        profileImageView.image = image
+        profileImageView.isHidden = !hasImage
+        fallbackIconView.isHidden = hasImage
+    }
+
+    private var strokeWeight: CGFloat {
+        if size < 40 { return 1 }
+        if size < 64 { return 2 }
+        if size < 160 { return 3 }
+        return 4
+    }
+}

--- a/MDS/Sources/Components/Avatar/MDSAvatar.swift
+++ b/MDS/Sources/Components/Avatar/MDSAvatar.swift
@@ -33,15 +33,25 @@ public final class MDSAvatar: UIView {
         didSet { layer.borderWidth = hasStroke ? strokeWeight : 0 }
     }
 
+    public var strokeColor: UIColor {
+        didSet { layer.borderColor = strokeColor.cgColor }
+    }
+
     private let size: CGFloat
 
     // MARK: - Init
 
     /// - Parameter size: 권고 사이즈 — 24, 32, 48, 56, 72, 80, 120, 180 (단위: pt)
-    public init(size: CGFloat, image: UIImage? = nil, hasStroke: Bool = false) {
+    public init(
+        size: CGFloat,
+        image: UIImage? = nil,
+        hasStroke: Bool = false,
+        strokeColor: UIColor = SemanticColor.Stroke.Secondary.default
+    ) {
         self.size = size
         self.image = image
         self.hasStroke = hasStroke
+        self.strokeColor = strokeColor
         super.init(frame: .zero)
         setupUI()
         setupLayout()
@@ -62,7 +72,7 @@ public final class MDSAvatar: UIView {
     private func setupUI() {
         layer.cornerRadius = size / 2
         layer.borderWidth = hasStroke ? strokeWeight : 0
-        layer.borderColor = SemanticColor.Stroke.Secondary.default.cgColor
+        layer.borderColor = strokeColor.cgColor
         layer.masksToBounds = true
 
         backgroundColor = SemanticColor.Bg.Neutral.ghost
@@ -102,6 +112,7 @@ public final class MDSAvatar: UIView {
         if size < 40 { return 1 }
         if size < 64 { return 2 }
         if size < 160 { return 3 }
-        return 4
+        if size < 180 { return 4 }
+        return 4 * (size / 180)
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#117

## 🌱 PR Point

**MDSAvatar 컴포넌트 구현**

| 파라미터 | 타입 | 기본값 | 설명 |
|:--|:--|:--|:--|
| `size` | `CGFloat` | — | 권고 사이즈: 24, 32, 48, 56, 72, 80, 120, 180 (pt) |
| `image` | `UIImage?` | `nil` | 프로필 이미지. nil이면 fallback 아이콘 표시 |
| `hasStroke` | `Bool` | `false` | 테두리 표시 여부 |
| `strokeColor` | `UIColor` | `SemanticColor.Stroke.Secondary.default` | 테두리 색상 |

**strokeWeight 계산 방식**

| 사이즈 | strokeWeight |
|:--:|:--:|
| < 40pt | 1 |
| < 64pt | 2 |
| < 160pt | 3 |
| < 180pt | 4 |
| ≥ 180pt | `4 × (size / 180)` |

180pt 이상의 커스텀 사이즈에서는 아바타 크기에 비례해 stroke 두께가 동적으로 계산돼요. (예: 360pt → strokeWeight = 8)

**Fallback 처리**

`image`가 nil일 때 `MDSIcon.userFilled`(단일 사람 아이콘)를 fallback으로 표시해요.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|MDSAvatar|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #117