### PR TITLE
[Feat] #120 - RadioButton 카탈로그 구현

### DIFF
--- a/MDSStoryBook/MDSStoryBook/Component/Control/ControlCategoryViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/Control/ControlCategoryViewController.swift
@@ -9,6 +9,7 @@ final class ControlCategoryViewController: UIViewController {
     private enum Category: String, CaseIterable {
         case checkbox = "Checkbox"
         case toggle = "Toggle"
+        case radioButton = "Radio Button"
     }
 
     private let categories = Category.allCases
@@ -64,6 +65,8 @@ extension ControlCategoryViewController: UITableViewDataSource, UITableViewDeleg
             navigationController?.pushViewController(CheckboxViewController(), animated: true)
         case .toggle:
             navigationController?.pushViewController(ToggleViewController(), animated: true)
+        case .radioButton:
+            navigationController?.pushViewController(RadioButtonViewController(), animated: true)
         }
     }
 }

--- a/MDSStoryBook/MDSStoryBook/Component/RadioButton/RadioButtonViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/RadioButton/RadioButtonViewController.swift
@@ -1,0 +1,136 @@
+//
+//  RadioButtonViewController.swift
+//  MDSStoryBook
+//
+//  Created by yungu0010 on 6/25/26.
+//
+
+import UIKit
+import MDS
+
+final class RadioButtonViewController: UIViewController {
+
+    private var radioGroups: [MDSRadioGroup] = []
+
+    private let scrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.delaysContentTouches = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let contentStack: UIStackView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.spacing = 32
+        view.layoutMargins = UIEdgeInsets(top: 24, left: 20, bottom: 24, right: 20)
+        view.isLayoutMarginsRelativeArrangement = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Radio Button"
+        view.backgroundColor = .systemGroupedBackground
+        setupLayout()
+        setupContent()
+    }
+
+    private func setupLayout() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+        ])
+    }
+
+    private func setupContent() {
+        contentStack.addArrangedSubview(makeSection(title: "Horizontal", axis: .horizontal))
+        contentStack.addArrangedSubview(makeSection(title: "Vertical", axis: .vertical))
+    }
+}
+
+// MARK: - Section Builders
+
+private extension RadioButtonViewController {
+
+    func makeSection(title: String, axis: NSLayoutConstraint.Axis) -> UIView {
+        let sectionTitle = UILabel()
+        sectionTitle.text = title
+        sectionTitle.font = .systemFont(ofSize: 20, weight: .bold)
+        sectionTitle.textColor = .label
+
+        let sectionStack = UIStackView()
+        sectionStack.axis = .vertical
+        sectionStack.spacing = 10
+        sectionStack.addArrangedSubview(sectionTitle)
+        sectionStack.addArrangedSubview(makeRow(label: "Small", size: .small, axis: axis))
+        sectionStack.addArrangedSubview(makeRow(label: "Large", size: .large, axis: axis))
+
+        return sectionStack
+    }
+
+    func makeRow(label: String, size: MDSRadioButton.Size, axis: NSLayoutConstraint.Axis) -> UIView {
+        let rowLabel = UILabel()
+        rowLabel.text = label
+        rowLabel.font = .systemFont(ofSize: 12, weight: .semibold)
+        rowLabel.textColor = .secondaryLabel
+
+        let buttons: [MDSRadioButton] = ["Option 1", "Option 2", "Option 3"].enumerated().map { index, text in
+            let button = MDSRadioButton(size: size)
+            button.labelText = text
+            button.isEnabled = index != 2
+            return button
+        }
+        buttons[0].isSelected = true
+
+        let group = MDSRadioGroup()
+        group.add(buttons)
+        radioGroups.append(group)
+
+        let rowStack = UIStackView()
+        rowStack.axis = .vertical
+        rowStack.spacing = 6
+        rowStack.addArrangedSubview(rowLabel)
+        rowStack.addArrangedSubview(makeCard(buttons: buttons, axis: axis))
+
+        return rowStack
+    }
+
+    func makeCard(buttons: [MDSRadioButton], axis: NSLayoutConstraint.Axis) -> UIView {
+        let card = UIView()
+        card.backgroundColor = SemanticColor.Bg.Dim.default
+        card.layer.cornerRadius = 12
+
+        let buttonStack = UIStackView()
+        buttonStack.axis = axis
+        buttonStack.spacing = axis == .horizontal ? 20 : 12
+        buttonStack.alignment = .leading
+        buttonStack.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        buttonStack.isLayoutMarginsRelativeArrangement = true
+        buttonStack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(buttonStack)
+
+        NSLayoutConstraint.activate([
+            buttonStack.topAnchor.constraint(equalTo: card.topAnchor),
+            buttonStack.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+            buttonStack.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            buttonStack.trailingAnchor.constraint(lessThanOrEqualTo: card.trailingAnchor),
+        ])
+
+        buttons.forEach { buttonStack.addArrangedSubview($0) }
+
+        return card
+    }
+}


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#120

## 🌱 PR Point

**스토리북 구조**

| 섹션 | 행 | 구성 |
|:--:|:--:|:--|
| Horizontal | Small / Large | Option 1(선택) · Option 2 · Option 3(비활성) 가로 배치 |
| Vertical | Small / Large | 동일 구성 세로 배치 |

`MDSRadioGroup`으로 섹션별 단일 선택을 보장하고, VC가 그룹 인스턴스를 소유(`radioGroups` 배열)해 ARC 해제를 방지했어요.

---

**`@MainActor`를 추가한 이유**

Swift 6 strict concurrency 환경에서 아래 경고가 발생했어요.

```
Sending value of non-Sendable type '(UIAction) -> Void' risks causing data races
```

`add(_ button:)` 내부에서 `UIAction` 클로저가 `self`를 `[weak self]`로 캡처할 때, 컴파일러가 Non-Sendable 타입의 클로저를 다른 격리 컨텍스트로 전달할 수 있다고 판단해서 경고가 떠요.

`MDSRadioGroup`은 UIKit 컴포넌트를 직접 제어하는 클래스이므로 메인 스레드에서만 사용해야 하는 타입이에요. `@MainActor`를 붙이면 클래스 전체가 메인 스레드에 격리되어 클로저도 암묵적으로 `@MainActor` 컨텍스트에서 실행됨을 컴파일러가 보장하고, 경고가 해소돼요.

**실제 프로덕트에서 사용할 때**

`UIViewController` / `UIView`는 이미 `@MainActor`이므로 일반 UI 코드에서는 아무 변화가 없어요.

```swift
// ViewController 내부 — 기존과 동일하게 사용
let group = MDSRadioGroup()
group.add([radio1, radio2, radio3])
```

백그라운드 `Task` 안에서 생성해야 하는 경우에만 명시적으로 hop이 필요해요.

```swift
Task {
    await MainActor.run {
        let group = MDSRadioGroup()
        group.add([radio1, radio2, radio3])
    }
}
```

단, 네트워크 응답이나 비동기 데이터를 받아서 UI를 구성하는 일반 패턴은 이미 `@MainActor` 컨텍스트(ex. `@MainActor func updateUI()`)에서 처리하므로 실질적인 영향은 없어요.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
https://github.com/user-attachments/assets/139807ce-ddb2-47f4-9f9a-600f11260c8b


## 📮 관련 이슈
- Resolved: #120