### PR TITLE
[Feat] #119 - AvatarViewController 구현

### DIFF
--- a/MDS/Sources/Components/Avatar/MDSAvatar.swift
+++ b/MDS/Sources/Components/Avatar/MDSAvatar.swift
@@ -1,0 +1,107 @@
+//
+//  MDSAvatar.swift
+//  MDS
+//
+
+import UIKit
+
+public final class MDSAvatar: UIView {
+
+    // MARK: - Private Views
+
+    private let profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let fallbackIconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    // MARK: - Properties
+
+    public var image: UIImage? {
+        didSet { applyImageState() }
+    }
+
+    public var strokeColor: UIColor {
+        didSet { layer.borderColor = strokeColor.cgColor }
+    }
+
+    private let size: CGFloat
+
+    // MARK: - Init
+
+    /// - Parameter size: 권고 사이즈 — 24, 32, 48, 56, 72, 80, 120, 180 (단위: pt)
+    public init(size: CGFloat, image: UIImage? = nil, strokeColor: UIColor = SemanticColor.Stroke.Neutral.ghost) {
+        self.size = size
+        self.image = image
+        self.strokeColor = strokeColor
+        super.init(frame: .zero)
+        setupUI()
+        setupLayout()
+        applyImageState()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - Layout
+
+    public override var intrinsicContentSize: CGSize {
+        CGSize(width: size, height: size)
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        layer.cornerRadius = size / 2
+        layer.borderWidth = strokeWeight
+        layer.borderColor = strokeColor.cgColor
+        layer.masksToBounds = true
+
+        backgroundColor = SemanticColor.Bg.Neutral.ghost
+
+        fallbackIconView.image = MDSIcon.usersFilled.image.withRenderingMode(.alwaysTemplate)
+        fallbackIconView.tintColor = SemanticColor.Fg.Neutral.bold
+    }
+
+    private func setupLayout() {
+        addSubview(profileImageView)
+        NSLayoutConstraint.activate([
+            profileImageView.topAnchor.constraint(equalTo: topAnchor),
+            profileImageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            profileImageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            profileImageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+
+        addSubview(fallbackIconView)
+        NSLayoutConstraint.activate([
+            fallbackIconView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            fallbackIconView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            fallbackIconView.widthAnchor.constraint(equalToConstant: size / 2),
+            fallbackIconView.heightAnchor.constraint(equalToConstant: size / 2)
+        ])
+    }
+
+    // MARK: - Apply
+
+    private func applyImageState() {
+        let hasImage = image != nil
+        profileImageView.image = image
+        profileImageView.isHidden = !hasImage
+        fallbackIconView.isHidden = hasImage
+    }
+
+    private var strokeWeight: CGFloat {
+        if size < 40 { return 1 }
+        if size < 64 { return 2 }
+        if size < 160 { return 3 }
+        return 4
+    }
+}

--- a/MDSStoryBook/MDSStoryBook.xcodeproj/project.pbxproj
+++ b/MDSStoryBook/MDSStoryBook.xcodeproj/project.pbxproj
@@ -366,8 +366,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sopt-makers/SOPT-iOS-MDS";
 			requirement = {
-				branch = default;
-				kind = branch;
+				kind = revision;
+				revision = a2581d6b12f6929243cf083fca93d4bd23588ca7;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/MDSStoryBook/MDSStoryBook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MDSStoryBook/MDSStoryBook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sopt-makers/SOPT-iOS-MDS",
       "state" : {
-        "branch" : "default",
-        "revision" : "5f31e22d390c6b6ce08210e248f4275ca7744fe6"
+        "revision" : "79740367f5f40ff1b9141d4d7886953d53e813f7"
       }
     }
   ],

--- a/MDSStoryBook/MDSStoryBook/Component/Avatar/AvatarViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/Avatar/AvatarViewController.swift
@@ -1,0 +1,185 @@
+//
+//  AvatarViewController.swift
+//  MDSStoryBook
+//
+
+import UIKit
+import MDS
+
+final class AvatarViewController: UIViewController {
+
+    private struct Variant {
+        let title: String
+        let hasStroke: Bool
+        let hasImage: Bool
+    }
+
+    private let variants: [Variant] = [
+        Variant(title: "Fallback", hasStroke: false, hasImage: false),
+        Variant(title: "Fallback + Stroke", hasStroke: true, hasImage: false),
+        Variant(title: "Image", hasStroke: false, hasImage: true),
+        Variant(title: "Image + Stroke", hasStroke: true, hasImage: true),
+    ]
+
+    private let recommendedSizes: [CGFloat] = [24, 32, 48, 56, 72, 80, 120, 180]
+
+    private let rainbowColors: [UIColor] = [
+        .systemRed, .systemOrange, .systemYellow, .systemGreen,
+        .systemBlue, .systemIndigo, .systemPurple, .systemPink
+    ]
+
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+
+    private let contentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 32
+        stack.layoutMargins = UIEdgeInsets(top: 24, left: 20, bottom: 24, right: 20)
+        stack.isLayoutMarginsRelativeArrangement = true
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Avatar"
+        view.backgroundColor = .systemGroupedBackground
+        setupLayout()
+        setupSections()
+    }
+
+    private func setupLayout() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+        ])
+    }
+
+    private func setupSections() {
+        for variant in variants {
+            contentStack.addArrangedSubview(makeVariantSection(variant: variant, sizes: recommendedSizes))
+        }
+
+        contentStack.addArrangedSubview(makeSectionHeader("커스텀 사이즈"))
+        contentStack.addArrangedSubview(makeCard(sizes: [44], hasStroke: false, hasImage: false))
+        contentStack.addArrangedSubview(makeCard(sizes: [44], hasStroke: true, hasImage: true))
+    }
+
+    private func makeVariantSection(variant: Variant, sizes: [CGFloat]) -> UIView {
+        let header = makeSectionHeader(variant.title)
+        let card = makeCard(sizes: sizes, hasStroke: variant.hasStroke, hasImage: variant.hasImage)
+
+        let sectionStack = UIStackView()
+        sectionStack.axis = .vertical
+        sectionStack.spacing = 8
+        sectionStack.addArrangedSubview(header)
+        sectionStack.addArrangedSubview(card)
+        return sectionStack
+    }
+
+    private func makeCard(sizes: [CGFloat], hasStroke: Bool, hasImage: Bool) -> UIView {
+        let card = UIView()
+        card.backgroundColor = SemanticColor.Bg.Dim.default
+        card.layer.cornerRadius = 12
+
+        let cardStack = UIStackView()
+        cardStack.axis = .vertical
+        cardStack.spacing = 20
+        cardStack.layoutMargins = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
+        cardStack.isLayoutMarginsRelativeArrangement = true
+        cardStack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(cardStack)
+
+        NSLayoutConstraint.activate([
+            cardStack.topAnchor.constraint(equalTo: card.topAnchor),
+            cardStack.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+            cardStack.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            cardStack.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+        ])
+
+        for (index, size) in sizes.enumerated() {
+            let strokeColor: UIColor = hasStroke
+                ? rainbowColors[index % rainbowColors.count]
+                : SemanticColor.Stroke.Secondary.default
+            cardStack.addArrangedSubview(
+                makeSizeRow(size: size, hasStroke: hasStroke, hasImage: hasImage, strokeColor: strokeColor)
+            )
+        }
+
+        return card
+    }
+
+    private func makeSizeRow(size: CGFloat, hasStroke: Bool, hasImage: Bool, strokeColor: UIColor) -> UIView {
+        let rowStack = UIStackView()
+        rowStack.axis = .horizontal
+        rowStack.alignment = .center
+        rowStack.spacing = 16
+
+        let sizeLabel = UILabel()
+        sizeLabel.text = "\(Int(size))pt"
+        sizeLabel.font = .monospacedDigitSystemFont(ofSize: 12, weight: .medium)
+        sizeLabel.textColor = SemanticColor.Fg.Neutral.subtle
+        sizeLabel.textAlignment = .right
+        sizeLabel.translatesAutoresizingMaskIntoConstraints = false
+        sizeLabel.widthAnchor.constraint(equalToConstant: 40).isActive = true
+
+        let avatar = MDSAvatar(
+            size: size,
+            image: hasImage ? makeSampleImage(size: size) : nil,
+            hasStroke: hasStroke,
+            strokeColor: strokeColor
+        )
+
+        let spacer = UIView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        rowStack.addArrangedSubview(sizeLabel)
+        rowStack.addArrangedSubview(avatar)
+        rowStack.addArrangedSubview(spacer)
+
+        return rowStack
+    }
+
+    private func makeSectionHeader(_ title: String) -> UILabel {
+        let label = UILabel()
+        label.text = title
+        label.font = .systemFont(ofSize: 13, weight: .semibold)
+        label.textColor = .secondaryLabel
+        return label
+    }
+
+    private func makeSampleImage(size: CGFloat) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: size, height: size))
+        return renderer.image { ctx in
+            UIColor.systemBlue.withAlphaComponent(0.4).setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: size, height: size))
+            let iconSize = size * 0.5
+            let iconRect = CGRect(
+                x: (size - iconSize) / 2,
+                y: (size - iconSize) / 2,
+                width: iconSize,
+                height: iconSize
+            )
+            let config = UIImage.SymbolConfiguration(pointSize: iconSize * 0.6, weight: .regular)
+            if let icon = UIImage(systemName: "photo.fill", withConfiguration: config) {
+                UIColor.white.setFill()
+                icon.draw(in: iconRect)
+            }
+        }
+    }
+}

--- a/MDSStoryBook/MDSStoryBook/Component/ComponentCategoryViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/ComponentCategoryViewController.swift
@@ -7,6 +7,7 @@ import UIKit
 
 final class ComponentCategoryViewController: UIViewController {
     private enum Category: String, CaseIterable {
+        case avatar = "Avatar"
         case chip = "Chip"
         case tag = "Tag"
         case callout = "Callout"
@@ -64,6 +65,8 @@ extension ComponentCategoryViewController: UITableViewDataSource, UITableViewDel
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         switch categories[indexPath.row] {
+        case .avatar:
+            navigationController?.pushViewController(AvatarViewController(), animated: true)
         case .chip:
             navigationController?.pushViewController(ChipViewController(), animated: true)
         case .tag:


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#119

## 🌱 PR Point

**스토리북 구조**

| 섹션 | 사이즈 | 구성 |
|:--:|:--:|:--|
| Fallback | 24 / 32 / 48 / 56 / 72 / 80 / 120 / 180pt | 이미지 없음, stroke 없음 |
| Fallback + Stroke | 24 / 32 / 48 / 56 / 72 / 80 / 120 / 180pt | 이미지 없음, 크기별 레인보우 stroke |
| Image | 24 / 32 / 48 / 56 / 72 / 80 / 120 / 180pt | 이미지 있음, stroke 없음 |
| Image + Stroke | 24 / 32 / 48 / 56 / 72 / 80 / 120 / 180pt | 이미지 있음, 크기별 레인보우 stroke |
| 커스텀 사이즈 | 44pt | Fallback / Image + Stroke 예시 |

stroke가 있는 섹션은 크기별로 빨·주·노·초·파·남·보·핑크 순서로 색상을 달리해 `strokeColor` 파라미터를 시각적으로 확인할 수 있어요.

샘플 이미지는 `photo.fill` SF Symbol을 사용해 fallback 아이콘(사람)과 구분돼요.

---

**SPM 참조**

`#117`의 최신 커밋(`strokeColor` 파라미터 추가 / strokeWeight 동적 계산)을 참조해요.
`#117` PR이 머지된 후 Package.resolved를 default 브랜치 기준으로 재설정이 필요해요.

## 📌 참고 사항
- `#117` 머지 후 Package.resolved 업데이트 필요

## 📸 스크린샷
https://github.com/user-attachments/assets/782d8dc7-1fd7-4559-9ba2-77982fd3f18d


## 📮 관련 이슈
- Resolved: #119