### PR TITLE
[Feat] #123 - MDSSearchField 구현

### DIFF
--- a/MDS/Sources/Components/Input/MDSSearchField.swift
+++ b/MDS/Sources/Components/Input/MDSSearchField.swift
@@ -1,0 +1,203 @@
+//
+//  MDSSearchField.swift
+//  MDS
+//
+
+import UIKit
+
+public final class MDSSearchField: UIView {
+
+    // MARK: - Nested Types
+
+    public enum Variant {
+        case `default`
+        case ghost
+    }
+
+    private enum State {
+        case `default`
+        case active
+        case filled
+    }
+
+    // MARK: - Public Properties
+
+    private let placeholder: String?
+
+    public var text: String? {
+        get { textField.text }
+        set {
+            textField.text = newValue
+            updateAppearance()
+        }
+    }
+
+    // MARK: - Private Properties
+
+    private let variant: Variant
+
+    // MARK: - Subviews
+
+    private let searchIconView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFit
+        view.image = MDSIcon.searchOutlined.image.withRenderingMode(.alwaysTemplate)
+        view.tintColor = SemanticColor.Fg.Neutral.default
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let textField: UITextField = {
+        let field = UITextField()
+        field.translatesAutoresizingMaskIntoConstraints = false
+        field.borderStyle = .none
+        field.font = Typography.body1.font
+        field.textColor = SemanticColor.Fg.Neutral.bold
+        field.returnKeyType = .search
+        return field
+    }()
+
+    private let clearButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(MDSIcon.xCloseOutlined.image.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.tintColor = SemanticColor.Fg.Neutral.bold
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.isHidden = true
+        return button
+    }()
+
+    // MARK: - Init
+
+    public init(variant: Variant = .default, placeholder: String? = nil) {
+        self.variant = variant
+        super.init(frame: .zero)
+        self.placeholder = placeholder
+        setupUI()
+        setupLayout()
+        initialAppearance()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        layer.cornerRadius = BaseRadius.Base.r10
+        layer.masksToBounds = true
+
+        textField.delegate = self
+        clearButton.addTarget(self, action: #selector(clearButtonTapped), for: .touchUpInside)
+    }
+
+    private func setupLayout() {
+        addSubview(searchIconView)
+        addSubview(textField)
+        addSubview(clearButton)
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: 48),
+
+            searchIconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
+            searchIconView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            searchIconView.widthAnchor.constraint(equalToConstant: 20),
+            searchIconView.heightAnchor.constraint(equalToConstant: 20),
+
+            textField.leadingAnchor.constraint(equalTo: searchIconView.trailingAnchor, constant: 8),
+            textField.centerYAnchor.constraint(equalTo: centerYAnchor),
+            textField.trailingAnchor.constraint(equalTo: clearButton.leadingAnchor, constant: -8),
+
+            clearButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
+            clearButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            clearButton.widthAnchor.constraint(equalToConstant: 20),
+            clearButton.heightAnchor.constraint(equalToConstant: 20),
+        ])
+    }
+
+    // init 시 한 번 호출. stored properties 값을 기반으로 초기 뷰 상태를 세팅한다.
+    private func initialAppearance() {
+        if let placeholder {
+            textField.attributedPlaceholder = NSAttributedString(
+                string: placeholder,
+                attributes: [
+                    .foregroundColor: SemanticColor.Fg.Neutral.ghost,
+                    .font: Typography.body1.font
+                ]
+            )
+        }
+        updateAppearance()
+    }
+
+    // MARK: - State
+
+    // 포커스, 텍스트 유무를 조합해 렌더링 상태를 계산한다. UI를 직접 변경하지 않는다.
+    private func resolvedState() -> State {
+        if textField.isFirstResponder { return .active }
+        if !(textField.text?.isEmpty ?? true) { return .filled }
+        return .default
+    }
+
+    // MARK: - Update
+
+    private func updateAppearance() {
+        let state = resolvedState()
+        backgroundColor = state.backgroundColor(for: variant)
+        layer.borderWidth = state.hasBorder ? 1 : 0
+        layer.borderColor = state.borderColor
+        clearButton.isHidden = state != .active || (textField.text?.isEmpty ?? true)
+    }
+
+    // MARK: - Actions
+
+    @objc private func clearButtonTapped() {
+        textField.text = nil
+        updateAppearance()
+    }
+}
+
+// MARK: - State Appearance
+
+private extension MDSSearchField.State {
+
+    func backgroundColor(for variant: MDSSearchField.Variant) -> UIColor {
+        switch variant {
+        case .default: return SemanticColor.Bg.Layer.default
+        case .ghost: return SemanticColor.Bg.Neutral.ghost
+        }
+    }
+
+    var hasBorder: Bool { self == .active }
+
+    var borderColor: CGColor? {
+        self == .active ? SemanticColor.Stroke.Neutral.Default.focused.cgColor : nil
+    }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension MDSSearchField: UITextFieldDelegate {
+
+    public func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        let currentText = textField.text ?? ""
+        let newText = (currentText as NSString).replacingCharacters(in: range, with: string)
+        clearButton.isHidden = newText.isEmpty
+        return true
+    }
+
+    public func textFieldDidBeginEditing(_ textField: UITextField) {
+        updateAppearance()
+    }
+
+    public func textFieldDidEndEditing(_ textField: UITextField) {
+        updateAppearance()
+    }
+
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+}


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#123

## 🌱 PR Point

### **State를 private으로 내려 외부 노출 제거**
- SearchField는 error / disabled 같은 외부 설정 상태가 없고, 상태가 전적으로 포커스·텍스트 유무에 의해 결정됩니다. public으로 노출할 이유가 없어 `private enum State`로 내리고, `resolvedState()`로 항상 계산하도록 했습니다.

### **clear 버튼을 Active 상태에서만 노출**
- Figma 스펙상 Filled 상태(포커스 없음 + 텍스트 있음)에서는 clear 버튼이 없습니다. 포커스가 있을 때만 지울 수 있도록 `state == .active && !text.isEmpty` 조건으로 변경했습니다.

### **보더를 Active 상태에서만 노출**
- Figma 스펙상 보더는 Active 상태에만 존재합니다. Default / Filled에서는 보더가 없습니다.

### **shouldChangeCharactersIn으로 clear 버튼 실시간 갱신**
- clear 버튼 가시성을 타이핑 중에도 실시간으로 반영하기 위해 `shouldChangeCharactersIn`에서 새 텍스트를 미리 계산해 직접 처리합니다. `@objc textFieldDidChange` target-action 없이 delegate만으로 처리할 수 있어 제거했습니다.

## 📌 참고 사항
- Variant에 따라 배경색이 다릅니다 (default: `Bg.Layer.default`, ghost: `Bg.Neutral.ghost`).
- 보더 색상은 Active 상태에서 `Stroke.Neutral.Default.focused`를 사용합니다.

## 📸 스크린샷
카탈로그 PR에서 첨부 예정

## 📮 관련 이슈
- Resolved: #123