### PR TITLE
[Add] #126 - Input 컴포넌트 인터랙티브 카탈로그 구현

### DIFF
--- a/MDS/Sources/Components/Input/MDSSearchField.swift
+++ b/MDS/Sources/Components/Input/MDSSearchField.swift
@@ -18,6 +18,19 @@ public final class MDSSearchField: UIView {
         case `default`
         case active
         case filled
+
+        func backgroundColor(for variant: MDSSearchField.Variant) -> UIColor {
+            switch variant {
+            case .default: return SemanticColor.Bg.Layer.default
+            case .ghost: return SemanticColor.Bg.Neutral.ghost
+            }
+        }
+
+        var hasBorder: Bool { self == .active }
+
+        var borderColor: CGColor? {
+            self == .active ? SemanticColor.Stroke.Neutral.Default.focused.cgColor : nil
+        }
     }
 
     // MARK: - Public Properties
@@ -70,8 +83,9 @@ public final class MDSSearchField: UIView {
 
     public init(variant: Variant = .default, placeholder: String? = nil) {
         self.variant = variant
-        super.init(frame: .zero)
         self.placeholder = placeholder
+        
+        super.init(frame: .zero)
         setupUI()
         setupLayout()
         initialAppearance()
@@ -152,24 +166,6 @@ public final class MDSSearchField: UIView {
     @objc private func clearButtonTapped() {
         textField.text = nil
         updateAppearance()
-    }
-}
-
-// MARK: - State Appearance
-
-private extension MDSSearchField.State {
-
-    func backgroundColor(for variant: MDSSearchField.Variant) -> UIColor {
-        switch variant {
-        case .default: return SemanticColor.Bg.Layer.default
-        case .ghost: return SemanticColor.Bg.Neutral.ghost
-        }
-    }
-
-    var hasBorder: Bool { self == .active }
-
-    var borderColor: CGColor? {
-        self == .active ? SemanticColor.Stroke.Neutral.Default.focused.cgColor : nil
     }
 }
 

--- a/MDS/Sources/Components/Input/MDSTextArea.swift
+++ b/MDS/Sources/Components/Input/MDSTextArea.swift
@@ -342,6 +342,7 @@ public final class MDSTextArea: UIView {
         textView.isSelectable = state != .disabled
         updateFieldStyle()
         updateHelperArea()
+        updateCounterLabel()
     }
 
     // 외부 state, 포커스, 텍스트 유무를 조합해 렌더링 상태를 계산한다. UI를 직접 변경하지 않는다.

--- a/MDS/Sources/Components/Input/MDSTextArea.swift
+++ b/MDS/Sources/Components/Input/MDSTextArea.swift
@@ -31,13 +31,35 @@ public final class MDSTextArea: UIView {
 
     // MARK: - Public Properties
 
-    public var label: String?
-    public var isRequired: Bool = false
-    public var descriptionText: String?
+    public var label: String? {
+        didSet {
+            labelLabel.text = label
+            labelRowView.isHidden = label == nil
+        }
+    }
+    public var isRequired: Bool = false {
+        didSet { requiredLabel.isHidden = !isRequired }
+    }
+    public var descriptionText: String? {
+        didSet {
+            descriptionLabel.text = descriptionText
+            descriptionLabel.isHidden = descriptionText == nil
+        }
+    }
     public var placeholder: String?
-    public var helperText: String?
-    public var errorMessage: String?
-    public var maxLength: Int?
+    public var helperText: String? {
+        didSet { updateHelperArea() }
+    }
+    public var errorMessage: String? {
+        didSet { if state == .error { updateHelperArea() } }
+    }
+    public var maxLength: Int? {
+        didSet {
+            counterLabel.isHidden = maxLength == nil
+            updateCounterLabel()
+            updateBottomRow()
+        }
+    }
     public var onSendTapped: (() -> Void)?
 
     public var sendButtonIcon: MDSIcon = .sendOutlined {
@@ -201,11 +223,27 @@ public final class MDSTextArea: UIView {
 
     // MARK: - Init
 
-    public init(variant: Variant = .default, hasSendButton: Bool = false, placeholder: String? = nil) {
+    public init(
+        variant: Variant = .default,
+        hasSendButton: Bool = false,
+        placeholder: String? = nil,
+        label: String? = nil,
+        isRequired: Bool = false,
+        descriptionText: String? = nil,
+        helperText: String? = nil,
+        errorMessage: String? = nil,
+        maxLength: Int? = nil
+    ) {
         self.variant = variant
         self.hasSendButton = hasSendButton
         super.init(frame: .zero)
         self.placeholder = placeholder
+        self.label = label
+        self.isRequired = isRequired
+        self.descriptionText = descriptionText
+        self.helperText = helperText
+        self.errorMessage = errorMessage
+        self.maxLength = maxLength
         setupUI()
         setupLayout()
         initialAppearance()

--- a/MDS/Sources/Components/Input/MDSTextArea.swift
+++ b/MDS/Sources/Components/Input/MDSTextArea.swift
@@ -33,7 +33,7 @@ public final class MDSTextArea: UIView {
 
     public var label: String? {
         didSet {
-            labelLabel.text = label
+            titleLabel.text = label
             labelRowView.isHidden = label == nil
         }
     }
@@ -104,11 +104,12 @@ public final class MDSTextArea: UIView {
         return stack
     }()
 
-    private let labelLabel: UILabel = {
+    private let titleLabel: UILabel = {
         let label = UILabel()
         label.font = Typography.title4.font
         label.textColor = SemanticColor.Fg.Neutral.bold
         label.numberOfLines = 1
+        label.setContentHuggingPriority(.required, for: .horizontal)
         return label
     }()
 
@@ -259,7 +260,7 @@ public final class MDSTextArea: UIView {
         sendButton.setImage(sendButtonIcon.image.withRenderingMode(.alwaysTemplate), for: .normal)
         sendButton.addTarget(self, action: #selector(sendButtonTapped), for: .touchUpInside)
 
-        labelRowView.addArrangedSubview(labelLabel)
+        labelRowView.addArrangedSubview(titleLabel)
         labelRowView.addArrangedSubview(requiredLabel)
 
         errorRowView.addArrangedSubview(errorIconView)
@@ -320,7 +321,7 @@ public final class MDSTextArea: UIView {
     // init 시 한 번 호출. stored properties 값을 기반으로 초기 뷰 상태를 세팅한다.
     private func initialAppearance() {
         labelRowView.isHidden = label == nil
-        labelLabel.text = label
+        titleLabel.text = label
         requiredLabel.isHidden = !isRequired
 
         descriptionLabel.isHidden = descriptionText == nil

--- a/MDS/Sources/Components/Input/MDSTextField.swift
+++ b/MDS/Sources/Components/Input/MDSTextField.swift
@@ -36,13 +36,35 @@ public final class MDSTextField: UIView {
 
     // MARK: - Public Properties
 
-    public var label: String?
-    public var isRequired: Bool = false
-    public var descriptionText: String?
+    public var label: String? {
+        didSet {
+            titleLabel.text = label
+            labelRowView.isHidden = label == nil
+        }
+    }
+    public var isRequired: Bool = false {
+        didSet { requiredLabel.isHidden = !isRequired }
+    }
+    public var descriptionText: String? {
+        didSet {
+            descriptionLabel.text = descriptionText
+            descriptionLabel.isHidden = descriptionText == nil
+        }
+    }
     public var placeholder: String?
-    public var helperText: String?
-    public var errorMessage: String?
-    public var maxLength: Int?
+    public var helperText: String? {
+        didSet { updateHelperArea() }
+    }
+    public var errorMessage: String? {
+        didSet { if state == .error { updateHelperArea() } }
+    }
+    public var maxLength: Int? {
+        didSet {
+            counterLabel.isHidden = maxLength == nil
+            updateCounterLabelContent()
+            updateBottomRow()
+        }
+    }
 
     public var text: String? {
         get { textField.text }
@@ -140,10 +162,25 @@ public final class MDSTextField: UIView {
 
     // MARK: - Init
 
-    public init(variant: Variant = .default, placeholder: String? = nil) {
+    public init(
+        variant: Variant = .default,
+        placeholder: String? = nil,
+        label: String? = nil,
+        isRequired: Bool = false,
+        descriptionText: String? = nil,
+        helperText: String? = nil,
+        errorMessage: String? = nil,
+        maxLength: Int? = nil
+    ) {
         self.variant = variant
         super.init(frame: .zero)
         self.placeholder = placeholder
+        self.label = label
+        self.isRequired = isRequired
+        self.descriptionText = descriptionText
+        self.helperText = helperText
+        self.errorMessage = errorMessage
+        self.maxLength = maxLength
         setupUI()
         setupLayout()
         initialAppearance()

--- a/MDS/Sources/Components/Input/MDSTextField.swift
+++ b/MDS/Sources/Components/Input/MDSTextField.swift
@@ -285,6 +285,7 @@ public final class MDSTextField: UIView {
         textField.isEnabled = state != .disabled
         updateFieldStyle()
         updateHelperArea()
+        updateCounterLabelContent()
     }
 
     // 외부 state, 포커스, 텍스트 유무를 조합해 렌더링 상태를 계산한다. UI를 직접 변경하지 않는다.

--- a/MDS/Sources/Components/Input/MDSTextField.swift
+++ b/MDS/Sources/Components/Input/MDSTextField.swift
@@ -27,6 +27,35 @@ public final class MDSTextField: UIView {
         case filled
         case error
         case disabled
+
+        func backgroundColor(for variant: MDSTextField.Variant) -> UIColor {
+            if variant == .ghost { return .clear }
+            return self == .disabled
+                ? SemanticColor.Bg.Neutral.Default.disabled
+                : SemanticColor.Bg.Neutral.ghost
+        }
+
+        var hasBorder: Bool {
+            self == .active || self == .error
+        }
+
+        var borderColor: CGColor? {
+            switch self {
+            case .active: return SemanticColor.Stroke.Neutral.Default.focused.cgColor
+            case .error: return SemanticColor.Stroke.Danger.default.cgColor
+            default: return nil
+            }
+        }
+
+        var ghostColor: UIColor {
+            self == .disabled ? SemanticColor.Fg.Neutral.Ghost.disabled : SemanticColor.Fg.Neutral.ghost
+        }
+
+        var foregroundColor: UIColor {
+            self == .disabled
+                ? SemanticColor.Fg.Neutral.Default.disabled
+                : SemanticColor.Fg.Neutral.bold
+        }
     }
 
     private enum Layout {
@@ -301,40 +330,6 @@ public final class MDSTextField: UIView {
 
     private func updateBottomRow() {
         bottomRowView.isHidden = helperLabel.isHidden && counterLabel.isHidden
-    }
-}
-
-// MARK: - ResolvedState Appearance
-
-private extension MDSTextField.ResolvedState {
-
-    func backgroundColor(for variant: MDSTextField.Variant) -> UIColor {
-        if variant == .ghost { return .clear }
-        return self == .disabled
-            ? SemanticColor.Bg.Neutral.Default.disabled
-            : SemanticColor.Bg.Neutral.ghost
-    }
-
-    var hasBorder: Bool {
-        self == .active || self == .error
-    }
-
-    var borderColor: CGColor? {
-        switch self {
-        case .active: return SemanticColor.Stroke.Neutral.Default.focused.cgColor
-        case .error: return SemanticColor.Stroke.Danger.default.cgColor
-        default: return nil
-        }
-    }
-
-    var ghostColor: UIColor {
-        self == .disabled ? SemanticColor.Fg.Neutral.Ghost.disabled : SemanticColor.Fg.Neutral.ghost
-    }
-
-    var foregroundColor: UIColor {
-        self == .disabled
-            ? SemanticColor.Fg.Neutral.Default.disabled
-            : SemanticColor.Fg.Neutral.bold
     }
 }
 

--- a/MDS/Sources/Components/Input/MDSTextField.swift
+++ b/MDS/Sources/Components/Input/MDSTextField.swift
@@ -136,6 +136,7 @@ public final class MDSTextField: UIView {
         label.numberOfLines = 1
         label.font = Typography.title4.font
         label.textColor = SemanticColor.Fg.Neutral.bold
+        label.setContentHuggingPriority(.required, for: .horizontal)
         return label
     }()
 

--- a/MDSStoryBook/MDSStoryBook/Component/Input/InputCategoryViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/Input/InputCategoryViewController.swift
@@ -1,21 +1,17 @@
 //
-//  ComponentCategoryViewController.swift
+//  InputCategoryViewController.swift
 //  MDSStoryBook
 //
 
 import UIKit
 
-final class ComponentCategoryViewController: UIViewController {
-    private enum Category: String, CaseIterable {
-        case avatar = "Avatar"
-        case chip = "Chip"
-        case tag = "Tag"
-        case callout = "Callout"
-        case button = "Button"
-        case control = "Control"
-        case input = "Input"
-    }
+final class InputCategoryViewController: UIViewController {
 
+    private enum Category: String, CaseIterable {
+        case searchField = "Search Field"
+        case textField = "Text Field"
+        case textArea = "Text Area"
+    }
 
     private let categories = Category.allCases
 
@@ -28,7 +24,7 @@ final class ComponentCategoryViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Component"
+        title = "Input"
         view.backgroundColor = .systemGroupedBackground
         setupLayout()
         setupTableView()
@@ -51,7 +47,8 @@ final class ComponentCategoryViewController: UIViewController {
     }
 }
 
-extension ComponentCategoryViewController: UITableViewDataSource, UITableViewDelegate {
+extension InputCategoryViewController: UITableViewDataSource, UITableViewDelegate {
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         categories.count
     }
@@ -66,20 +63,12 @@ extension ComponentCategoryViewController: UITableViewDataSource, UITableViewDel
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         switch categories[indexPath.row] {
-        case .avatar:
-            navigationController?.pushViewController(AvatarViewController(), animated: true)
-        case .chip:
-            navigationController?.pushViewController(ChipViewController(), animated: true)
-        case .tag:
-            navigationController?.pushViewController(TagViewController(), animated: true)
-        case .callout:
-            navigationController?.pushViewController(CalloutViewController(), animated: true)
-        case .button:
-            navigationController?.pushViewController(ButtonCategoryViewController(), animated: true)
-        case .control:
-            navigationController?.pushViewController(ControlCategoryViewController(), animated: true)
-        case .input:
-            navigationController?.pushViewController(InputCategoryViewController(), animated: true)
+        case .searchField:
+            navigationController?.pushViewController(SearchFieldViewController(), animated: true)
+        case .textField:
+            navigationController?.pushViewController(TextFieldViewController(), animated: true)
+        case .textArea:
+            navigationController?.pushViewController(TextAreaViewController(), animated: true)
         }
     }
 }

--- a/MDSStoryBook/MDSStoryBook/Component/Input/SearchFieldViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/Input/SearchFieldViewController.swift
@@ -1,0 +1,89 @@
+//
+//  SearchFieldViewController.swift
+//  MDSStoryBook
+//
+
+import UIKit
+import MDS
+
+final class SearchFieldViewController: UIViewController {
+
+    private let scrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let contentStack: UIStackView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.spacing = 32
+        view.layoutMargins = UIEdgeInsets(top: 24, left: 20, bottom: 24, right: 20)
+        view.isLayoutMarginsRelativeArrangement = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Search Field"
+        view.backgroundColor = .systemGroupedBackground
+        setupLayout()
+        setupContent()
+    }
+
+    private func setupLayout() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+        ])
+    }
+
+    private func setupContent() {
+        let variants: [(title: String, variant: MDSSearchField.Variant)] = [
+            ("Default", .default),
+            ("Ghost", .ghost),
+        ]
+        variants.forEach { item in
+            contentStack.addArrangedSubview(makeVariantSection(title: item.title, variant: item.variant))
+        }
+    }
+
+    private func makeVariantSection(title: String, variant: MDSSearchField.Variant) -> UIView {
+        let sectionTitle = UILabel()
+        sectionTitle.text = title
+        sectionTitle.font = .systemFont(ofSize: 20, weight: .bold)
+        sectionTitle.textColor = .label
+
+        let field = MDSSearchField(variant: variant, placeholder: "Search")
+        field.translatesAutoresizingMaskIntoConstraints = false
+
+        let card = UIView()
+        card.backgroundColor = SemanticColor.Bg.Dim.default
+        card.layer.cornerRadius = 12
+        card.addSubview(field)
+
+        NSLayoutConstraint.activate([
+            field.topAnchor.constraint(equalTo: card.topAnchor, constant: 16),
+            field.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 16),
+            field.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -16),
+            field.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -16),
+        ])
+
+        let section = UIStackView(arrangedSubviews: [sectionTitle, card])
+        section.axis = .vertical
+        section.spacing = 10
+        return section
+    }
+}

--- a/MDSStoryBook/MDSStoryBook/Component/Input/TextAreaViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/Input/TextAreaViewController.swift
@@ -155,11 +155,15 @@ final class TextAreaViewController: UIViewController {
 
         let variantControl = UISegmentedControl(items: ["Default", "Ghost"])
         variantControl.selectedSegmentIndex = 0
+        variantControl.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .normal)
+        variantControl.setTitleTextAttributes([.foregroundColor: UIColor.black], for: .selected)
         variantControl.addTarget(self, action: #selector(variantChanged(_:)), for: .valueChanged)
         stack.addArrangedSubview(makeControlRow(title: "Variant", control: variantControl))
 
         let stateControl = UISegmentedControl(items: ["Default", "Error", "Disabled"])
         stateControl.selectedSegmentIndex = 0
+        stateControl.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .normal)
+        stateControl.setTitleTextAttributes([.foregroundColor: UIColor.black], for: .selected)
         stateControl.addTarget(self, action: #selector(stateChanged(_:)), for: .valueChanged)
         stack.addArrangedSubview(makeControlRow(title: "State", control: stateControl))
 

--- a/MDSStoryBook/MDSStoryBook/Component/Input/TextAreaViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/Input/TextAreaViewController.swift
@@ -1,0 +1,305 @@
+//
+//  TextAreaViewController.swift
+//  MDSStoryBook
+//
+
+import UIKit
+import MDS
+
+final class TextAreaViewController: UIViewController {
+
+    // MARK: - Options State
+
+    private var fieldVariant: MDSTextArea.Variant = .default
+    private var fieldState: MDSTextArea.State = .default
+    private var showLabel = false
+    private var showRequired = false
+    private var showDescription = false
+    private var showHelperText = false
+    private var showTextCounter = false
+    private var showSendButton = false
+
+    // MARK: - Control References
+
+    private weak var requiredSwitch: UISwitch?
+    private var previewTextArea: MDSTextArea!
+
+    // MARK: - Subviews
+
+    private let scrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.keyboardDismissMode = .interactive
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let contentStack: UIStackView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.spacing = 24
+        view.layoutMargins = UIEdgeInsets(top: 24, left: 20, bottom: 24, right: 20)
+        view.isLayoutMarginsRelativeArrangement = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let previewCard: UIView = {
+        let view = UIView()
+        view.backgroundColor = SemanticColor.Bg.Dim.default
+        view.layer.cornerRadius = 12
+        return view
+    }()
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Text Area"
+        view.backgroundColor = .systemGroupedBackground
+        setupLayout()
+        addPreviewSection()
+        addControlsSection()
+        setupTextArea()
+        setupKeyboardHandling()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: - Layout
+
+    private func setupLayout() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+        ])
+    }
+
+    // MARK: - Preview
+
+    private func addPreviewSection() {
+        contentStack.addArrangedSubview(makeSectionTitle("Preview"))
+        contentStack.addArrangedSubview(previewCard)
+    }
+
+    private func setupTextArea() {
+        previewTextArea?.removeFromSuperview()
+
+        let ta = MDSTextArea(
+            variant: fieldVariant,
+            hasSendButton: showSendButton,
+            placeholder: "Placeholder text",
+            errorMessage: "Error message"
+        )
+        ta.translatesAutoresizingMaskIntoConstraints = false
+        previewCard.addSubview(ta)
+
+        NSLayoutConstraint.activate([
+            ta.topAnchor.constraint(equalTo: previewCard.topAnchor, constant: 16),
+            ta.leadingAnchor.constraint(equalTo: previewCard.leadingAnchor, constant: 16),
+            ta.trailingAnchor.constraint(equalTo: previewCard.trailingAnchor, constant: -16),
+            ta.bottomAnchor.constraint(equalTo: previewCard.bottomAnchor, constant: -16),
+        ])
+
+        previewTextArea = ta
+        applyCurrentOptions()
+    }
+
+    private func applyCurrentOptions() {
+        previewTextArea.label = showLabel ? "Label" : nil
+        previewTextArea.isRequired = showLabel && showRequired
+        previewTextArea.descriptionText = showDescription ? "Input description" : nil
+        previewTextArea.helperText = showHelperText ? "Helper text" : nil
+        previewTextArea.maxLength = showTextCounter ? 100 : nil
+        previewTextArea.state = fieldState
+    }
+
+    // MARK: - Controls
+
+    private func addControlsSection() {
+        contentStack.addArrangedSubview(makeSectionTitle("Controls"))
+        contentStack.addArrangedSubview(makeControlsCard())
+    }
+
+    private func makeControlsCard() -> UIView {
+        let card = UIView()
+        card.backgroundColor = SemanticColor.Bg.Dim.default
+        card.layer.cornerRadius = 12
+
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        stack.isLayoutMarginsRelativeArrangement = true
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: card.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+        ])
+
+        let variantControl = UISegmentedControl(items: ["Default", "Ghost"])
+        variantControl.selectedSegmentIndex = 0
+        variantControl.addTarget(self, action: #selector(variantChanged(_:)), for: .valueChanged)
+        stack.addArrangedSubview(makeControlRow(title: "Variant", control: variantControl))
+
+        let stateControl = UISegmentedControl(items: ["Default", "Error", "Disabled"])
+        stateControl.selectedSegmentIndex = 0
+        stateControl.addTarget(self, action: #selector(stateChanged(_:)), for: .valueChanged)
+        stack.addArrangedSubview(makeControlRow(title: "State", control: stateControl))
+
+        stack.addArrangedSubview(makeSeparator())
+
+        stack.addArrangedSubview(makeSwitchRow(title: "Label", action: #selector(labelToggled(_:))).view)
+
+        let requiredRow = makeSwitchRow(title: "Required (*)", action: #selector(requiredToggled(_:)))
+        requiredRow.toggle.isEnabled = false
+        requiredSwitch = requiredRow.toggle
+        stack.addArrangedSubview(requiredRow.view)
+
+        stack.addArrangedSubview(makeSwitchRow(title: "Description", action: #selector(descriptionToggled(_:))).view)
+        stack.addArrangedSubview(makeSwitchRow(title: "Helper Text", action: #selector(helperTextToggled(_:))).view)
+        stack.addArrangedSubview(makeSwitchRow(title: "Text Counter", action: #selector(textCounterToggled(_:))).view)
+        stack.addArrangedSubview(makeSwitchRow(title: "Send Button", action: #selector(sendButtonToggled(_:))).view)
+
+        return card
+    }
+
+    // MARK: - Row Builders
+
+    private func makeSectionTitle(_ text: String) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.font = .systemFont(ofSize: 20, weight: .bold)
+        label.textColor = .label
+        return label
+    }
+
+    private func makeControlRow(title: String, control: UIView) -> UIView {
+        let label = UILabel()
+        label.text = title
+        label.font = .systemFont(ofSize: 13)
+        label.textColor = UIColor.white.withAlphaComponent(0.6)
+
+        let stack = UIStackView(arrangedSubviews: [label, control])
+        stack.axis = .vertical
+        stack.spacing = 6
+        return stack
+    }
+
+    private func makeSwitchRow(title: String, action: Selector) -> (view: UIStackView, toggle: UISwitch) {
+        let label = UILabel()
+        label.text = title
+        label.font = .systemFont(ofSize: 15)
+        label.textColor = .white
+
+        let toggle = UISwitch()
+        toggle.addTarget(self, action: action, for: .valueChanged)
+
+        let stack = UIStackView(arrangedSubviews: [label, toggle])
+        stack.axis = .horizontal
+        stack.distribution = .equalSpacing
+        stack.alignment = .center
+        return (stack, toggle)
+    }
+
+    private func makeSeparator() -> UIView {
+        let view = UIView()
+        view.backgroundColor = .separator
+        view.heightAnchor.constraint(equalToConstant: 0.5).isActive = true
+        return view
+    }
+
+    // MARK: - Keyboard
+
+    private func setupKeyboardHandling() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow(_:)),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+    }
+
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+        scrollView.contentInset.bottom = frame.height - view.safeAreaInsets.bottom
+    }
+
+    @objc private func keyboardWillHide() {
+        scrollView.contentInset.bottom = 0
+    }
+
+    // MARK: - Actions
+
+    @objc private func variantChanged(_ sender: UISegmentedControl) {
+        fieldVariant = sender.selectedSegmentIndex == 0 ? .default : .ghost
+        setupTextArea()
+    }
+
+    @objc private func stateChanged(_ sender: UISegmentedControl) {
+        switch sender.selectedSegmentIndex {
+        case 1: fieldState = .error
+        case 2: fieldState = .disabled
+        default: fieldState = .default
+        }
+        previewTextArea.state = fieldState
+    }
+
+    @objc private func labelToggled(_ sender: UISwitch) {
+        showLabel = sender.isOn
+        if !sender.isOn {
+            showRequired = false
+            requiredSwitch?.setOn(false, animated: true)
+        }
+        requiredSwitch?.isEnabled = sender.isOn
+        previewTextArea.label = showLabel ? "Label" : nil
+        previewTextArea.isRequired = showLabel && showRequired
+    }
+
+    @objc private func requiredToggled(_ sender: UISwitch) {
+        showRequired = sender.isOn
+        previewTextArea.isRequired = sender.isOn
+    }
+
+    @objc private func descriptionToggled(_ sender: UISwitch) {
+        showDescription = sender.isOn
+        previewTextArea.descriptionText = sender.isOn ? "Input description" : nil
+    }
+
+    @objc private func helperTextToggled(_ sender: UISwitch) {
+        showHelperText = sender.isOn
+        previewTextArea.helperText = sender.isOn ? "Helper text" : nil
+    }
+
+    @objc private func textCounterToggled(_ sender: UISwitch) {
+        showTextCounter = sender.isOn
+        previewTextArea.maxLength = sender.isOn ? 100 : nil
+    }
+
+    @objc private func sendButtonToggled(_ sender: UISwitch) {
+        showSendButton = sender.isOn
+        setupTextArea()
+    }
+}

--- a/MDSStoryBook/MDSStoryBook/Component/Input/TextFieldViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/Input/TextFieldViewController.swift
@@ -1,0 +1,297 @@
+//
+//  TextFieldViewController.swift
+//  MDSStoryBook
+//
+
+import UIKit
+import MDS
+
+final class TextFieldViewController: UIViewController {
+
+    // MARK: - Options State
+
+    private var fieldVariant: MDSTextField.Variant = .default
+    private var fieldState: MDSTextField.State = .default
+    private var showLabel = false
+    private var showRequired = false
+    private var showDescription = false
+    private var showHelperText = false
+    private var showTextCounter = false
+
+    // MARK: - Control References
+
+    private weak var requiredSwitch: UISwitch?
+    private var previewTextField: MDSTextField!
+
+    // MARK: - Subviews
+
+    private let scrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.keyboardDismissMode = .interactive
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let contentStack: UIStackView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.spacing = 24
+        view.layoutMargins = UIEdgeInsets(top: 24, left: 20, bottom: 24, right: 20)
+        view.isLayoutMarginsRelativeArrangement = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let previewCard: UIView = {
+        let view = UIView()
+        view.backgroundColor = SemanticColor.Bg.Dim.default
+        view.layer.cornerRadius = 12
+        return view
+    }()
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Text Field"
+        view.backgroundColor = .systemGroupedBackground
+        setupLayout()
+        addPreviewSection()
+        addControlsSection()
+        setupTextField()
+        setupKeyboardHandling()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: - Layout
+
+    private func setupLayout() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+        ])
+    }
+
+    // MARK: - Preview
+
+    private func addPreviewSection() {
+        contentStack.addArrangedSubview(makeSectionTitle("Preview"))
+        contentStack.addArrangedSubview(previewCard)
+    }
+
+    private func setupTextField() {
+        previewTextField?.removeFromSuperview()
+
+        let tf = MDSTextField(
+            variant: fieldVariant,
+            placeholder: "Placeholder text",
+            errorMessage: "Error message"
+        )
+        tf.translatesAutoresizingMaskIntoConstraints = false
+        previewCard.addSubview(tf)
+
+        NSLayoutConstraint.activate([
+            tf.topAnchor.constraint(equalTo: previewCard.topAnchor, constant: 16),
+            tf.leadingAnchor.constraint(equalTo: previewCard.leadingAnchor, constant: 16),
+            tf.trailingAnchor.constraint(equalTo: previewCard.trailingAnchor, constant: -16),
+            tf.bottomAnchor.constraint(equalTo: previewCard.bottomAnchor, constant: -16),
+        ])
+
+        previewTextField = tf
+        applyCurrentOptions()
+    }
+
+    private func applyCurrentOptions() {
+        previewTextField.label = showLabel ? "Label" : nil
+        previewTextField.isRequired = showLabel && showRequired
+        previewTextField.descriptionText = showDescription ? "Input description" : nil
+        previewTextField.helperText = showHelperText ? "Helper text" : nil
+        previewTextField.maxLength = showTextCounter ? 50 : nil
+        previewTextField.state = fieldState
+    }
+
+    // MARK: - Controls
+
+    private func addControlsSection() {
+        contentStack.addArrangedSubview(makeSectionTitle("Controls"))
+        contentStack.addArrangedSubview(makeControlsCard())
+    }
+
+    private func makeControlsCard() -> UIView {
+        let card = UIView()
+        card.backgroundColor = SemanticColor.Bg.Dim.default
+        card.layer.cornerRadius = 12
+
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        stack.isLayoutMarginsRelativeArrangement = true
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: card.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+        ])
+
+        let variantControl = UISegmentedControl(items: ["Default", "Ghost"])
+        variantControl.selectedSegmentIndex = 0
+        variantControl.addTarget(self, action: #selector(variantChanged(_:)), for: .valueChanged)
+        stack.addArrangedSubview(makeControlRow(title: "Variant", control: variantControl))
+
+        let stateControl = UISegmentedControl(items: ["Default", "Error", "Disabled"])
+        stateControl.selectedSegmentIndex = 0
+        stateControl.addTarget(self, action: #selector(stateChanged(_:)), for: .valueChanged)
+        stack.addArrangedSubview(makeControlRow(title: "State", control: stateControl))
+
+        stack.addArrangedSubview(makeSeparator())
+
+        stack.addArrangedSubview(makeSwitchRow(title: "Label", action: #selector(labelToggled(_:))).view)
+
+        let requiredRow = makeSwitchRow(title: "Required (*)", action: #selector(requiredToggled(_:)))
+        requiredRow.toggle.isEnabled = false
+        requiredSwitch = requiredRow.toggle
+        stack.addArrangedSubview(requiredRow.view)
+
+        stack.addArrangedSubview(makeSwitchRow(title: "Description", action: #selector(descriptionToggled(_:))).view)
+        stack.addArrangedSubview(makeSwitchRow(title: "Helper Text", action: #selector(helperTextToggled(_:))).view)
+        stack.addArrangedSubview(makeSwitchRow(title: "Text Counter", action: #selector(textCounterToggled(_:))).view)
+
+        return card
+    }
+
+    // MARK: - Row Builders
+
+    private func makeSectionTitle(_ text: String) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.font = .systemFont(ofSize: 20, weight: .bold)
+        label.textColor = .label
+        return label
+    }
+
+    private func makeControlRow(title: String, control: UIView) -> UIView {
+        let label = UILabel()
+        label.text = title
+        label.font = .systemFont(ofSize: 13)
+        label.textColor = UIColor.white.withAlphaComponent(0.6)
+
+        let stack = UIStackView(arrangedSubviews: [label, control])
+        stack.axis = .vertical
+        stack.spacing = 6
+        return stack
+    }
+
+    private func makeSwitchRow(title: String, action: Selector) -> (view: UIStackView, toggle: UISwitch) {
+        let label = UILabel()
+        label.text = title
+        label.font = .systemFont(ofSize: 15)
+        label.textColor = .white
+
+        let toggle = UISwitch()
+        toggle.addTarget(self, action: action, for: .valueChanged)
+
+        let stack = UIStackView(arrangedSubviews: [label, toggle])
+        stack.axis = .horizontal
+        stack.distribution = .equalSpacing
+        stack.alignment = .center
+        return (stack, toggle)
+    }
+
+    private func makeSeparator() -> UIView {
+        let view = UIView()
+        view.backgroundColor = .separator
+        view.heightAnchor.constraint(equalToConstant: 0.5).isActive = true
+        return view
+    }
+
+    // MARK: - Keyboard
+
+    private func setupKeyboardHandling() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow(_:)),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+    }
+
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+        scrollView.contentInset.bottom = frame.height - view.safeAreaInsets.bottom
+    }
+
+    @objc private func keyboardWillHide() {
+        scrollView.contentInset.bottom = 0
+    }
+
+    // MARK: - Actions
+
+    @objc private func variantChanged(_ sender: UISegmentedControl) {
+        fieldVariant = sender.selectedSegmentIndex == 0 ? .default : .ghost
+        setupTextField()
+    }
+
+    @objc private func stateChanged(_ sender: UISegmentedControl) {
+        switch sender.selectedSegmentIndex {
+        case 1: fieldState = .error
+        case 2: fieldState = .disabled
+        default: fieldState = .default
+        }
+        previewTextField.state = fieldState
+    }
+
+    @objc private func labelToggled(_ sender: UISwitch) {
+        showLabel = sender.isOn
+        if !sender.isOn {
+            showRequired = false
+            requiredSwitch?.setOn(false, animated: true)
+        }
+        requiredSwitch?.isEnabled = sender.isOn
+        previewTextField.label = showLabel ? "Label" : nil
+        previewTextField.isRequired = showLabel && showRequired
+    }
+
+    @objc private func requiredToggled(_ sender: UISwitch) {
+        showRequired = sender.isOn
+        previewTextField.isRequired = sender.isOn
+    }
+
+    @objc private func descriptionToggled(_ sender: UISwitch) {
+        showDescription = sender.isOn
+        previewTextField.descriptionText = sender.isOn ? "Input description" : nil
+    }
+
+    @objc private func helperTextToggled(_ sender: UISwitch) {
+        showHelperText = sender.isOn
+        previewTextField.helperText = sender.isOn ? "Helper text" : nil
+    }
+
+    @objc private func textCounterToggled(_ sender: UISwitch) {
+        showTextCounter = sender.isOn
+        previewTextField.maxLength = sender.isOn ? 50 : nil
+    }
+}

--- a/MDSStoryBook/MDSStoryBook/Component/Input/TextFieldViewController.swift
+++ b/MDSStoryBook/MDSStoryBook/Component/Input/TextFieldViewController.swift
@@ -153,11 +153,15 @@ final class TextFieldViewController: UIViewController {
 
         let variantControl = UISegmentedControl(items: ["Default", "Ghost"])
         variantControl.selectedSegmentIndex = 0
+        variantControl.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .normal)
+        variantControl.setTitleTextAttributes([.foregroundColor: UIColor.black], for: .selected)
         variantControl.addTarget(self, action: #selector(variantChanged(_:)), for: .valueChanged)
         stack.addArrangedSubview(makeControlRow(title: "Variant", control: variantControl))
 
         let stateControl = UISegmentedControl(items: ["Default", "Error", "Disabled"])
         stateControl.selectedSegmentIndex = 0
+        stateControl.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .normal)
+        stateControl.setTitleTextAttributes([.foregroundColor: UIColor.black], for: .selected)
         stateControl.addTarget(self, action: #selector(stateChanged(_:)), for: .valueChanged)
         stack.addArrangedSubview(makeControlRow(title: "State", control: stateControl))
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#126

## 🌱 PR Point

### 1. `MDSTextField`, `MDSTextArea` init 파라미터 확장 및 didSet 추가

기존에는 init 이후 외부에서 `label`, `helperText` 등의 프로퍼티를 변경해도 UI에 반영되지 않았습니다.
카탈로그처럼 런타임에 프로퍼티를 동적으로 바꾸는 상황에서는 변경이 즉시 뷰에 반영되어야 하므로, 각 프로퍼티에 `didSet`을 추가해 내부 update 메서드를 호출하도록 했습니다.
init 파라미터도 함께 확장해 초기값을 코드에서 바로 주입할 수 있도록 통일했습니다.

### 2. `State`, `ResolvedState` 프로퍼티를 enum 본문 안으로 이동

`private enum` 에 대해 `private extension TypeName.PrivateEnum` 형태로 extension을 작성하면, Swift 컴파일러가 해당 중첩 타입을 찾지 못해 컴파일 에러가 발생합니다.
`private` nested type 은 외부 extension 의 접근 대상이 될 수 없다는 Swift 컴파일러의 제약이 원인이었습니다.
따라서 `backgroundColor`, `hasBorder` 등 외관 관련 프로퍼티·메서드를 enum 본문 안으로 직접 이동해 해결했습니다.

### 3. Input 카탈로그 구현 방식

`UIScrollView + UIStackView` 기반으로 **Preview** 영역과 **Controls** 영역을 분리해 구성했습니다.
- **Preview**: 실제 컴포넌트를 그대로 올려, 컨트롤 변경 시 라이브로 결과를 확인할 수 있게 했습니다.
- **Controls**: `UISegmentedControl`(Variant, State)과 `UISwitch`(Label · Required · Description · Helper Text · Text Counter 등 옵션별 토글)로 구성했습니다.

컨트롤에서 값을 바꿀 때 컴포넌트의 public 프로퍼티를 직접 조작하는 방식을 택했습니다. 실제 사용 측에서 프로퍼티를 직접 설정하는 패턴을 카탈로그가 그대로 재현하기 위해서입니다.

## 📌 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷

https://github.com/user-attachments/assets/ab411a85-a89e-4412-a535-ecc5e59beb58

https://github.com/user-attachments/assets/cfaa58d6-a5ed-4e03-9e4c-5302616e0296

https://github.com/user-attachments/assets/34c752da-8bcb-4899-9bdc-ee1555cef25e




## 📮 관련 이슈
- Resolved: #126