### PR TITLE
[Fix] #133 - Typography line-height/letter-spacing 전수 반영

### DIFF
--- a/MDS/Sources/Adapters/UILabel+Typography.swift
+++ b/MDS/Sources/Adapters/UILabel+Typography.swift
@@ -6,7 +6,10 @@
 import UIKit
 
 extension UILabel {
-    public func setTypography(_ style: MDSFont) {
+    /// `style`의 font/lineHeight/letterSpacing을 attributedText로 반영합니다.
+    /// attributedText가 설정되면 UILabel.textColor는 무시되므로, textColor를 명시적으로 전달하거나
+    /// 호출 전에 self.textColor를 먼저 설정해야 합니다. text가 바뀔 때마다 다시 호출해야 합니다.
+    public func setTypography(_ style: MDSFont, textColor: UIColor? = nil) {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.minimumLineHeight = style.lineHeight
         paragraphStyle.maximumLineHeight = style.lineHeight
@@ -14,6 +17,7 @@ extension UILabel {
         let attributes: [NSAttributedString.Key: Any] = [
             .font: style.font,
             .kern: style.letterSpacing,
+            .foregroundColor: textColor ?? self.textColor ?? UIColor.label,
             .paragraphStyle: paragraphStyle,
             .baselineOffset: (style.lineHeight - style.font.lineHeight) / 4
         ]

--- a/MDS/Sources/Components/Button/ActionButton/MDSActionButton.swift
+++ b/MDS/Sources/Components/Button/ActionButton/MDSActionButton.swift
@@ -142,11 +142,7 @@ public final class MDSActionButton: UIControl {
 
         titleLabel.attributedText = NSAttributedString(
             string: title ?? "",
-            attributes: [
-                .font: sizeToken.typography.font,
-                .kern: sizeToken.typography.letterSpacing,
-                .foregroundColor: colorToken.foreground
-            ]
+            attributes: sizeToken.typography.attributedStringAttributes(foregroundColor: colorToken.foreground)
         )
 
         prefixImageView.image = prefixIcon?.withRenderingMode(.alwaysTemplate)

--- a/MDS/Sources/Components/Button/FloatingButton/MDSFloatingButton.swift
+++ b/MDS/Sources/Components/Button/FloatingButton/MDSFloatingButton.swift
@@ -126,11 +126,7 @@ public final class MDSFloatingButton: UIControl {
 
         titleLabel.attributedText = NSAttributedString(
             string: label ?? "",
-            attributes: [
-                .font: sizeToken.typography.font,
-                .kern: sizeToken.typography.letterSpacing,
-                .foregroundColor: colorToken.foreground,
-            ]
+            attributes: sizeToken.typography.attributedStringAttributes(foregroundColor: colorToken.foreground)
         )
     }
 }

--- a/MDS/Sources/Components/Button/ReactionButton/MDSReactionButton.swift
+++ b/MDS/Sources/Components/Button/ReactionButton/MDSReactionButton.swift
@@ -136,11 +136,7 @@ public final class MDSReactionButton: UIControl {
     private func updateAppearance() {
         let sizeToken = SizeToken(size: size)
         let colorToken = ColorToken(isSelected: isSelected, isEnabled: isEnabled)
-        let textAttributes: [NSAttributedString.Key: Any] = [
-            .font: sizeToken.typography.font,
-            .kern: sizeToken.typography.letterSpacing,
-            .foregroundColor: colorToken.foreground
-        ]
+        let textAttributes = sizeToken.typography.attributedStringAttributes(foregroundColor: colorToken.foreground)
         
         contentStackView.spacing = sizeToken.itemGap
         

--- a/MDS/Sources/Components/Button/TextButton/MDSTextButton.swift
+++ b/MDS/Sources/Components/Button/TextButton/MDSTextButton.swift
@@ -121,11 +121,7 @@ public final class MDSTextButton: UIControl {
         
         textLabel.attributedText = NSAttributedString(
             string: title,
-            attributes: [
-                .font: sizeToken.typography.font,
-                .kern: sizeToken.typography.letterSpacing,
-                .foregroundColor: colorToken.foreground
-            ]
+            attributes: sizeToken.typography.attributedStringAttributes(foregroundColor: colorToken.foreground)
         )
         chevronImageView.tintColor = colorToken.foreground
         

--- a/MDS/Sources/Components/Callout/MDSCallout.swift
+++ b/MDS/Sources/Components/Callout/MDSCallout.swift
@@ -103,7 +103,8 @@ extension MDSCallout {
     ) {
         let colorToken = ColorToken(style: style)
         label.text = text
-        
+        label.setTypography(Typography.body2)
+
         containerStackView.backgroundColor = colorToken.background
         containerStackView.layer.borderColor = colorToken.stroke.cgColor
         
@@ -122,10 +123,7 @@ extension MDSCallout {
             config.attributedTitle = AttributedString(
                 NSAttributedString(
                     string: buttonTitle,
-                    attributes: [
-                        .font: Typography.label4.font,
-                        .foregroundColor: SemanticColor.Fg.Neutral.bold
-                    ]
+                    attributes: Typography.label4.attributedStringAttributes(foregroundColor: SemanticColor.Fg.Neutral.bold)
                 )
             )
             config.image = MDSIcon.chevronRightOutlined.image

--- a/MDS/Sources/Components/Chip/MDSChip.swift
+++ b/MDS/Sources/Components/Chip/MDSChip.swift
@@ -61,11 +61,7 @@ public final class MDSChip: UIButton {
         config.attributedTitle = AttributedString(
             NSAttributedString(
                 string: chipTitle ?? "",
-                attributes: [
-                    .font: typography.font,
-                    .kern: typography.letterSpacing,
-                    .foregroundColor: textColor
-                ]
+                attributes: typography.attributedStringAttributes(foregroundColor: textColor)
             )
         )
     }

--- a/MDS/Sources/Components/Control/Checkbox/MDSCheckbox.swift
+++ b/MDS/Sources/Components/Control/Checkbox/MDSCheckbox.swift
@@ -89,8 +89,8 @@ public final class MDSCheckbox: UIControl {
 
     private func setupLayout() {
         let sizeToken = SizeToken(size: checkboxSize)
-        
-        titleLabel.font = sizeToken.font
+
+        titleLabel.font = sizeToken.font.font
         contentStackView.spacing = sizeToken.padding
 
         NSLayoutConstraint.activate([
@@ -112,6 +112,7 @@ public final class MDSCheckbox: UIControl {
     private func setTitle(title: String?) {
         if let title {
             self.titleLabel.text = title
+            self.titleLabel.setTypography(SizeToken(size: checkboxSize).font)
         } else {
             self.titleLabel.isHidden = true
         }
@@ -137,6 +138,7 @@ public final class MDSCheckbox: UIControl {
         checkImageView.isHidden = !isSelected
 
         titleLabel.textColor = colorToken.textColor
+        titleLabel.setTypography(SizeToken(size: checkboxSize).font)
     }
 }
 
@@ -146,20 +148,20 @@ private extension MDSCheckbox {
     struct SizeToken {
         let iconSize: CGFloat
         let boxSize: CGFloat
-        let font: UIFont
+        let font: MDSFont
         let padding: CGFloat
-        
+
         init(size: Size) {
             switch size {
             case .small:
                 iconSize = 12
                 boxSize = 16
-                font = Typography.label3.font
+                font = Typography.label3
                 padding = 6
             case .large:
                 iconSize = 15
                 boxSize = 20
-                font = Typography.label2.font
+                font = Typography.label2
                 padding = 8
             }
         }

--- a/MDS/Sources/Components/Control/RadioButton/MDSRadioButton.swift
+++ b/MDS/Sources/Components/Control/RadioButton/MDSRadioButton.swift
@@ -134,11 +134,7 @@ public final class MDSRadioButton: UIControl {
         titleLabel.isHidden = false
         titleLabel.attributedText = NSAttributedString(
             string: text,
-            attributes: [
-                .font: sizeToken.typography.font,
-                .kern: sizeToken.typography.letterSpacing,
-                .foregroundColor: colorToken.labelColor
-            ]
+            attributes: sizeToken.typography.attributedStringAttributes(foregroundColor: colorToken.labelColor)
         )
     }
 }

--- a/MDS/Sources/Components/Input/MDSSearchField.swift
+++ b/MDS/Sources/Components/Input/MDSSearchField.swift
@@ -135,7 +135,8 @@ public final class MDSSearchField: UIView {
                 string: placeholder,
                 attributes: [
                     .foregroundColor: SemanticColor.Fg.Neutral.ghost,
-                    .font: Typography.body1.font
+                    .font: Typography.body1.font,
+                    .kern: Typography.body1.letterSpacing
                 ]
             )
         }

--- a/MDS/Sources/Components/Input/MDSTextArea.swift
+++ b/MDS/Sources/Components/Input/MDSTextArea.swift
@@ -34,6 +34,7 @@ public final class MDSTextArea: UIView {
     public var label: String? {
         didSet {
             titleLabel.text = label
+            titleLabel.setTypography(Typography.title4)
             labelRowView.isHidden = label == nil
         }
     }
@@ -43,6 +44,7 @@ public final class MDSTextArea: UIView {
     public var descriptionText: String? {
         didSet {
             descriptionLabel.text = descriptionText
+            descriptionLabel.setTypography(Typography.label3)
             descriptionLabel.isHidden = descriptionText == nil
         }
     }
@@ -118,6 +120,7 @@ public final class MDSTextArea: UIView {
         label.text = "*"
         label.font = Typography.title4.font
         label.textColor = SemanticColor.Fg.Brand.default
+        label.setTypography(Typography.title4)
         return label
     }()
 
@@ -322,12 +325,15 @@ public final class MDSTextArea: UIView {
     private func initialAppearance() {
         labelRowView.isHidden = label == nil
         titleLabel.text = label
+        titleLabel.setTypography(Typography.title4)
         requiredLabel.isHidden = !isRequired
 
         descriptionLabel.isHidden = descriptionText == nil
         descriptionLabel.text = descriptionText
+        descriptionLabel.setTypography(Typography.label3)
 
         placeholderLabel.text = placeholder
+        placeholderLabel.setTypography(Typography.body1)
 
         counterLabel.isHidden = maxLength == nil
 
@@ -364,6 +370,7 @@ public final class MDSTextArea: UIView {
         inputContainer.layer.borderColor = state.borderColor
         textView.textColor = state.textColor
         placeholderLabel.textColor = state.ghostColor
+        placeholderLabel.setTypography(Typography.body1)
     }
 
     private func updateHelperArea() {
@@ -372,16 +379,19 @@ public final class MDSTextArea: UIView {
             helperLabel.isHidden = true
             errorRowView.isHidden = false
             errorMessageLabel.text = message
+            errorMessageLabel.setTypography(Typography.body2)
         } else if let helper = helperText {
             helperLabel.isHidden = false
             helperLabel.text = helper
             helperLabel.textColor = state.ghostColor
+            helperLabel.setTypography(Typography.body2)
             errorRowView.isHidden = true
         } else {
             helperLabel.isHidden = true
             errorRowView.isHidden = true
         }
         counterLabel.textColor = state.ghostColor
+        counterLabel.setTypography(Typography.body2)
         updateBottomRow()
     }
 
@@ -389,6 +399,7 @@ public final class MDSTextArea: UIView {
         guard let maxLength else { return }
         counterLabel.text = "\(textView.text.count)/\(maxLength)"
         counterLabel.textColor = resolvedState().ghostColor
+        counterLabel.setTypography(Typography.body2)
     }
 
     private func updateBottomRow() {
@@ -446,6 +457,7 @@ extension MDSTextArea: UITextViewDelegate {
         let newText = (currentText as NSString).replacingCharacters(in: range, with: text)
         guard newText.count <= maxLength else { return false }
         counterLabel.text = "\(newText.count)/\(maxLength)"
+        counterLabel.setTypography(Typography.body2)
         return true
     }
 

--- a/MDS/Sources/Components/Input/MDSTextField.swift
+++ b/MDS/Sources/Components/Input/MDSTextField.swift
@@ -68,6 +68,7 @@ public final class MDSTextField: UIView {
     public var label: String? {
         didSet {
             titleLabel.text = label
+            titleLabel.setTypography(Typography.title4)
             labelRowView.isHidden = label == nil
         }
     }
@@ -77,6 +78,7 @@ public final class MDSTextField: UIView {
     public var descriptionText: String? {
         didSet {
             descriptionLabel.text = descriptionText
+            descriptionLabel.setTypography(Typography.label3)
             descriptionLabel.isHidden = descriptionText == nil
         }
     }
@@ -145,6 +147,7 @@ public final class MDSTextField: UIView {
         label.text = "*"
         label.font = Typography.title4.font
         label.textColor = SemanticColor.Fg.Brand.default
+        label.setTypography(Typography.title4)
         return label
     }()
 
@@ -261,17 +264,20 @@ public final class MDSTextField: UIView {
                 string: placeholder,
                 attributes: [
                     .foregroundColor: SemanticColor.Fg.Neutral.ghost,
-                    .font: Typography.body1.font
+                    .font: Typography.body1.font,
+                    .kern: Typography.body1.letterSpacing
                 ]
             )
         }
 
         labelRowView.isHidden = label == nil
         titleLabel.text = label
+        titleLabel.setTypography(Typography.title4)
         requiredLabel.isHidden = !isRequired
 
         descriptionLabel.isHidden = descriptionText == nil
         descriptionLabel.text = descriptionText
+        descriptionLabel.setTypography(Typography.label3)
 
         counterLabel.isHidden = maxLength == nil
 
@@ -314,10 +320,12 @@ public final class MDSTextField: UIView {
             helperLabel.isHidden = false
             helperLabel.text = message
             helperLabel.textColor = SemanticColor.Fg.Danger.default
+            helperLabel.setTypography(Typography.body2)
         } else if let helper = helperText {
             helperLabel.isHidden = false
             helperLabel.text = helper
             helperLabel.textColor = effectiveState.ghostColor
+            helperLabel.setTypography(Typography.body2)
         } else {
             helperLabel.isHidden = true
         }
@@ -328,6 +336,7 @@ public final class MDSTextField: UIView {
         guard let maxLength else { return }
         counterLabel.text = "\(textField.text?.count ?? 0)/\(maxLength)"
         counterLabel.textColor = resolvedState().ghostColor
+        counterLabel.setTypography(Typography.body2)
     }
 
     private func updateBottomRow() {
@@ -349,6 +358,7 @@ extension MDSTextField: UITextFieldDelegate {
         let newText = (currentText as NSString).replacingCharacters(in: range, with: string)
         guard newText.count <= maxLength else { return false }
         counterLabel.text = "\(newText.count)/\(maxLength)"
+        counterLabel.setTypography(Typography.body2)
         return true
     }
 

--- a/MDS/Sources/Components/Tag/MDSTag.swift
+++ b/MDS/Sources/Components/Tag/MDSTag.swift
@@ -98,6 +98,7 @@ public final class MDSTag: UIView {
         label.font = sizeToken.font.font
         label.textColor = colorToken.foreground
         label.text = text
+        label.setTypography(sizeToken.font)
 
         applyIcon(icon, size: sizeToken.iconSize, tintColor: colorToken.foreground)
     }

--- a/MDS/Sources/Foundation/MDSFont.swift
+++ b/MDS/Sources/Foundation/MDSFont.swift
@@ -11,4 +11,20 @@ public struct MDSFont: @unchecked Sendable {
     public let font: UIFont
     public let lineHeight: CGFloat
     public let letterSpacing: CGFloat
+
+    /// font/lineHeight/letterSpacing을 모두 반영한 NSAttributedString.Key 속성을 반환합니다.
+    /// UILabel이 아닌 곳(UIButton.Configuration.attributedTitle 등)에서 typography를 적용할 때 사용합니다.
+    public func attributedStringAttributes(foregroundColor: UIColor) -> [NSAttributedString.Key: Any] {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.minimumLineHeight = lineHeight
+        paragraphStyle.maximumLineHeight = lineHeight
+
+        return [
+            .font: font,
+            .kern: letterSpacing,
+            .foregroundColor: foregroundColor,
+            .paragraphStyle: paragraphStyle,
+            .baselineOffset: (lineHeight - font.lineHeight) / 4
+        ]
+    }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#133

## 🌱 PR Point

### 1. `setTypography(_:)` 미사용 문제

`MDSFont`는 `font`, `lineHeight`, `letterSpacing`을 함께 정의하고 있고, 이를 UILabel에 반영하는 `UILabel.setTypography(_:)` 헬퍼(`UILabel+Typography.swift`)도 이미 존재했습니다.
하지만 저장소 전체에서 이 메서드가 한 번도 호출되지 않고, 대신 `label.font = Typography.x.font` 형태로 UIFont만 가져다 쓰고 있었습니다. 
그 결과 `lineHeight`/`letterSpacing` 토큰이 도입된 이후 단 한 번도 실제로 반영되지 않았습니다. (Figma: title4 → lineHeight 26px 스펙과 실제 렌더링이 어긋나는 문제에서 발견)

### 2. `setTypography(_:)` 자체의 버그 수정

기존 구현은 `attributedText`를 새로 만들면서 `.foregroundColor`를 지정하지 않아, 그대로 호출하면 `UILabel.textColor`가 무시되어 색상이 깨지는 문제가 있었습니다. `foregroundColor` 파라미터를 추가해 해결했습니다.

### 3. 적용 범위

`MDSFont`에 `attributedStringAttributes(foregroundColor:)` 헬퍼를 추가해 `UIButton.attributedTitle` 등 UILabel이 아닌 곳에서 반복되던 paragraphStyle/baselineOffset 보일러플레이트를 제거했습니다.

다음 12개 컴포넌트에 반영했습니다: `MDSTextField`, `MDSTextArea`, `MDSSearchField`, `MDSCallout`, `MDSChip`, `MDSTag`, `MDSTextButton`, `MDSActionButton`, `MDSFloatingButton`, `MDSReactionButton`, `MDSRadioButton`, `MDSCheckbox`

동적으로 텍스트가 바뀌는 라벨(예: `titleLabel`, `counterLabel`, `helperLabel`)은 텍스트/색상이 바뀔 때마다 `setTypography`를 재호출하도록 처리했습니다.

## 📌 참고 사항

- `#126`이 아직 `default`에 머지되지 않아, 이 PR은 `default`가 아닌 `feature/#126-input-catalog`를 base로 잡았습니다. `#126` 머지 후 base를 `default`로 옮기거나 rebase 예정입니다.
- line-height/letter-spacing 변경 폭이 1~2pt 수준이라 육안으로는 차이가 크지 않을 수 있습니다. UIKit 레이어(Xcode View Debugger 등)에서 라벨 프레임 높이나 attributedText의 `NSParagraphStyle`을 확인하는 편이 더 명확합니다.
- `xcodebuild`로 MDS 패키지, MDSStoryBook 앱 둘 다 빌드 성공 확인했습니다.

## 📸 스크린샷
적용 전에에는 height가 21.6이었지만 적용 후 height가 26으로 고정됨.
<img width="720" height="341" alt="image" src="https://github.com/user-attachments/assets/9830377a-ec22-41f6-ad68-8466df1a9565" />


## 📮 관련 이슈
- Resolved: #133